### PR TITLE
CTCP-538: Allow percent sign on changes to report form

### DIFF
--- a/app/models/Seals.scala
+++ b/app/models/Seals.scala
@@ -26,7 +26,7 @@ object Seals {
 
   val maxSeals     = 9999
   val sealIdLength = 20
-  val sealIdRegex  = "^[a-zA-Z0-9&'@/.\\-%? ]*$"
+  val sealIdRegex  = "^[a-zA-Z0-9&'@/.\\%? -]*$"
 
   implicit val xmlReader: XmlReader[Seals] = (
     (__ \ "SeaNumSLI2").read[Int],

--- a/app/models/messages/UnloadingRemarksRequest.scala
+++ b/app/models/messages/UnloadingRemarksRequest.scala
@@ -46,7 +46,7 @@ object UnloadingRemarksRequest {
   val alphaNumericRegex          = "^[a-zA-Z0-9 ]*$"
   val grossMassRegex             = "^(\\d{1,11}|(\\d{0,11}\\.{1}\\d{1,3}){1})$"
   val grossMassLength            = 15
-  val stringFieldRegex           = "[\\sa-zA-Z0-9&'@/.\\-? ]*"
+  val stringFieldRegex           = "^[a-zA-Z0-9&'@/.\\%? -]*$"
 
   implicit def writes: XMLWrites[UnloadingRemarksRequest] = XMLWrites[UnloadingRemarksRequest] {
     unloadingRemarksRequest =>

--- a/test/forms/behaviours/FieldBehaviours.scala
+++ b/test/forms/behaviours/FieldBehaviours.scala
@@ -42,7 +42,7 @@ trait FieldBehaviours extends FormSpec with ScalaCheckPropertyChecks with Genera
       result.errors shouldEqual Seq(requiredError)
     }
 
-    "must  not bind blank values" in {
+    "must not bind blank values" in {
 
       val result = form.bind(Map(fieldName -> "")).apply(fieldName)
       result.errors shouldEqual Seq(requiredError)


### PR DESCRIPTION
The "What do you need to report?" page was not allowing percent signs, despite them being a valid character:

![image](https://user-images.githubusercontent.com/238270/170263227-1b0282cd-c7a8-4c7b-b4a2-cc3906234e9a.png)

I've updated the regex to match the regex for the "What is the new official customs seal number or mark?" input as both allow the same character set.

Also - I've updated the regex slightly as the hyphen (-) needs to be at the beginning or end of the character set otherwise it's considered a range identifier.