### PR TITLE
Removed hc children from parent cross-check page.

### DIFF
--- a/app/utils/answersHelpers/ConsignmentAnswersHelper.scala
+++ b/app/utils/answersHelpers/ConsignmentAnswersHelper.scala
@@ -147,6 +147,7 @@ class ConsignmentAnswersHelper(userAnswers: UserAnswers)(implicit messages: Mess
 
       }
 
+  // Don't show children sections here. These are accessed from the 'More details' link
   def houseConsignmentSections: Seq[Section] =
     userAnswers.get(HouseConsignmentsSection).mapWithIndex {
       (_, houseConsignmentIndex) =>
@@ -161,7 +162,6 @@ class ConsignmentAnswersHelper(userAnswers: UserAnswers)(implicit messages: Mess
         AccordionSection(
           sectionTitle = messages("unloadingFindings.subsections.houseConsignment", houseConsignmentIndex.display),
           rows = rows,
-          children = helper.itemSections,
           viewLink = Link(
             id = s"view-house-consignment-${houseConsignmentIndex.display}",
             href = controllers.routes.HouseConsignmentController.onPageLoad(arrivalId, houseConsignmentIndex).url,

--- a/test/utils/answersHelpers/ConsignmentAnswersHelperSpec.scala
+++ b/test/utils/answersHelpers/ConsignmentAnswersHelperSpec.scala
@@ -147,6 +147,7 @@ class ConsignmentAnswersHelperSpec extends AnswersHelperSpecBase {
             result.head.rows(1).value.value mustBe consignorId
             result.head.rows(2).value.value mustBe consigneeName
             result.head.rows(3).value.value mustBe consigneeId
+            result.head.children mustBe empty
             val link = result.head.viewLink.value
             link.id mustBe "view-house-consignment-1"
             link.text mustBe "View"


### PR DESCRIPTION
<img width="514" alt="Screenshot 2024-02-23 at 13 33 52" src="https://github.com/hmrc/manage-transit-movements-unloading-frontend/assets/43777106/417b297b-7163-4f76-8482-938dd6112283">
