### PR TITLE
CTCP-5047

### DIFF
--- a/app/utils/answersHelpers/ConsignmentAnswersHelper.scala
+++ b/app/utils/answersHelpers/ConsignmentAnswersHelper.scala
@@ -18,7 +18,7 @@ package utils.answersHelpers
 
 import models.DocType.Previous
 import models.reference.CustomsOffice
-import models.{Index, Link, NormalMode, RichOptionalJsArray, SecurityType, UserAnswers}
+import models.{Link, RichOptionalJsArray, SecurityType, UserAnswers}
 import pages.documents.TypePage
 import pages.grossMass.GrossMassPage
 import pages.sections._
@@ -201,16 +201,12 @@ class ConsignmentAnswersHelper(userAnswers: UserAnswers)(implicit messages: Mess
         )
       case sectionsRows =>
         val transportEquipments = sectionsRows.map {
-          case (container, sealsSection, itemsSection, index) =>
-            val containerSection = container.map(
-              x => StaticSection(rows = Seq(x))
-            )
-
+          case (containerRow, sealsSection, itemsSection, index) =>
             AccordionSection(
               sectionTitle = Some(messages("unloadingFindings.subsections.transportEquipment", index.display)),
               viewLinks = Nil,
+              rows = Seq(containerRow).flatten,
               children = Seq(
-                containerSection,
                 sealsSection,
                 itemsSection
               ).flatten,

--- a/app/utils/answersHelpers/ConsignmentAnswersHelper.scala
+++ b/app/utils/answersHelpers/ConsignmentAnswersHelper.scala
@@ -188,10 +188,11 @@ class ConsignmentAnswersHelper(userAnswers: UserAnswers)(implicit messages: Mess
   def transportEquipmentSection: Section =
     userAnswers.get(TransportEquipmentListSection).mapWithIndex {
       case (_, index) =>
-        val helper                = new TransportEquipmentAnswersHelper(userAnswers, index)
-        val containerAndSealsRows = Seq(helper.containerIdentificationNumber, helper.transportEquipmentSeals).flatten
-        val itemsRows             = Seq(helper.transportEquipmentItems).flatten
-        (containerAndSealsRows, itemsRows, index)
+        val helper       = new TransportEquipmentAnswersHelper(userAnswers, index)
+        val container    = helper.containerIdentificationNumber
+        val sealsSection = helper.transportEquipmentSeals
+        val itemsSection = helper.transportEquipmentItems
+        (container, sealsSection, itemsSection, index)
     } match {
       case Nil =>
         StaticSection(
@@ -200,25 +201,19 @@ class ConsignmentAnswersHelper(userAnswers: UserAnswers)(implicit messages: Mess
         )
       case sectionsRows =>
         val transportEquipments = sectionsRows.map {
-          case (containerAndSeals, items, index) =>
-            val containerAndSealsSection =
-              StaticSection(
-                rows = containerAndSeals,
-                viewLinks = Seq(sealsAddRemoveLink(index))
-              )
-
-            val itemsSection =
-              StaticSection(
-                sectionTitle = None,
-                rows = items,
-                viewLinks = Seq(itemsAddRemoveLink(index)),
-                optionalInformationHeading = if (items.isEmpty) None else Some(messages("unloadingFindings.informationHeading.consignment.item"))
-              )
+          case (container, sealsSection, itemsSection, index) =>
+            val containerSection = container.map(
+              x => StaticSection(rows = Seq(x))
+            )
 
             AccordionSection(
               sectionTitle = Some(messages("unloadingFindings.subsections.transportEquipment", index.display)),
               viewLinks = Nil,
-              children = Seq(containerAndSealsSection, itemsSection),
+              children = Seq(
+                containerSection,
+                sealsSection,
+                itemsSection
+              ).flatten,
               id = Some(s"transportEquipment$index")
             )
         }
@@ -431,22 +426,6 @@ class ConsignmentAnswersHelper(userAnswers: UserAnswers)(implicit messages: Mess
       href = "#",
       text = messages("departureTransportMeans.addRemove"),
       visuallyHidden = messages("departureTransportMeans.visuallyHidden")
-    )
-
-  private def sealsAddRemoveLink(index: Index): Link =
-    Link(
-      id = s"add-remove-seals-${index.display}",
-      href = controllers.transportEquipment.index.routes.AddAnotherSealController.onPageLoad(arrivalId, NormalMode, index).url,
-      text = messages("sealsLink.addRemove"),
-      visuallyHidden = messages("sealsLink.visuallyHidden")
-    )
-
-  private def itemsAddRemoveLink(index: Index): Link =
-    Link(
-      id = s"add-remove-consignment-items-${index.display}",
-      href = controllers.transportEquipment.index.routes.ApplyAnotherItemController.onPageLoad(arrivalId, NormalMode, index).url,
-      text = messages("consignmentItemLink.addRemove", index.display),
-      visuallyHidden = messages("consignmentItemLink.visuallyHidden", index.display)
     )
 
   private val transportEquipmentAddRemoveLink: Link = Link(

--- a/app/utils/answersHelpers/consignment/TransportEquipmentAnswersHelper.scala
+++ b/app/utils/answersHelpers/consignment/TransportEquipmentAnswersHelper.scala
@@ -58,7 +58,7 @@ class TransportEquipmentAnswersHelper(
             sectionTitle = Some(messages("unloadingFindings.subsections.seals")),
             rows = rows.flatten,
             id = Some(s"transport-equipment-$equipmentIndex-seals"),
-            viewLinks = Seq(sealsAddRemoveLink(equipmentIndex))
+            viewLinks = Seq(sealsAddRemoveLink)
           )
         )
     }
@@ -79,24 +79,24 @@ class TransportEquipmentAnswersHelper(
             sectionTitle = Some(messages("unloadingFindings.subsections.goodsReferences")),
             rows = rows.flatten,
             id = Some(s"transport-equipment-$equipmentIndex-items"),
-            viewLinks = Seq(itemsAddRemoveLink(equipmentIndex))
+            viewLinks = Seq(itemsAddRemoveLink)
           )
         )
     }
 
-  private def sealsAddRemoveLink(index: Index): Link =
+  private def sealsAddRemoveLink: Link =
     Link(
-      id = s"add-remove-seals-${index.display}",
-      href = controllers.transportEquipment.index.routes.AddAnotherSealController.onPageLoad(arrivalId, NormalMode, index).url,
+      id = s"add-remove-transport-equipment-${equipmentIndex.display}-seal",
+      href = controllers.transportEquipment.index.routes.AddAnotherSealController.onPageLoad(arrivalId, NormalMode, equipmentIndex).url,
       text = messages("sealsLink.addRemove"),
       visuallyHidden = messages("sealsLink.visuallyHidden")
     )
 
-  private def itemsAddRemoveLink(index: Index): Link =
+  private def itemsAddRemoveLink: Link =
     Link(
-      id = s"add-remove-consignment-items-${index.display}",
-      href = controllers.transportEquipment.index.routes.ApplyAnotherItemController.onPageLoad(arrivalId, NormalMode, index).url,
-      text = messages("consignmentItemLink.addRemove", index.display),
-      visuallyHidden = messages("consignmentItemLink.visuallyHidden", index.display)
+      id = s"add-remove-transport-equipment-${equipmentIndex.display}-item",
+      href = controllers.transportEquipment.index.routes.ApplyAnotherItemController.onPageLoad(arrivalId, NormalMode, equipmentIndex).url,
+      text = messages("consignmentItemLink.addRemove", equipmentIndex.display),
+      visuallyHidden = messages("consignmentItemLink.visuallyHidden", equipmentIndex.display)
     )
 }

--- a/app/utils/answersHelpers/consignment/TransportEquipmentAnswersHelper.scala
+++ b/app/utils/answersHelpers/consignment/TransportEquipmentAnswersHelper.scala
@@ -16,7 +16,7 @@
 
 package utils.answersHelpers.consignment
 
-import models.{CheckMode, Index, UserAnswers}
+import models.{CheckMode, Index, Link, NormalMode, RichOptionalJsArray, UserAnswers}
 import pages.ContainerIdentificationNumberPage
 import pages.sections.SealsSection
 import pages.sections.transport.equipment.ItemsSection
@@ -24,6 +24,8 @@ import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import utils.answersHelpers.AnswersHelper
 import utils.answersHelpers.consignment.transportEquipment.{ItemAnswersHelper, SealAnswersHelper}
+import viewModels.sections.Section
+import viewModels.sections.Section.AccordionSection
 
 class TransportEquipmentAnswersHelper(
   userAnswers: UserAnswers,
@@ -40,17 +42,61 @@ class TransportEquipmentAnswersHelper(
     call = Some(controllers.transportEquipment.index.routes.ContainerIdentificationNumberController.onPageLoad(arrivalId, equipmentIndex, CheckMode))
   )
 
-  def transportEquipmentSeals: Seq[SummaryListRow] =
-    getAnswersAndBuildSectionRows(SealsSection(equipmentIndex)) {
-      index =>
-        val helper = new SealAnswersHelper(userAnswers, equipmentIndex, index)
-        helper.transportEquipmentSeal
+  def transportEquipmentSeals: Option[Section] =
+    userAnswers
+      .get(SealsSection(equipmentIndex))
+      .mapWithIndex {
+        case (_, index) =>
+          val helper = new SealAnswersHelper(userAnswers, equipmentIndex, index)
+          Seq(helper.transportEquipmentSeal).flatten
+      }
+      .toList match {
+      case Nil => None
+      case rows =>
+        Some(
+          AccordionSection(
+            sectionTitle = Some("Seals"),
+            rows = rows.flatten,
+            id = Some(s"transport-equipment-$equipmentIndex-seals"),
+            viewLinks = Seq(sealsAddRemoveLink(equipmentIndex))
+          )
+        )
     }
 
-  def transportEquipmentItems: Seq[SummaryListRow] =
-    getAnswersAndBuildSectionRows(ItemsSection(equipmentIndex)) {
-      index =>
-        val helper = new ItemAnswersHelper(userAnswers, equipmentIndex, index)
-        helper.transportEquipmentItem
+  def transportEquipmentItems: Option[Section] =
+    userAnswers
+      .get(ItemsSection(equipmentIndex))
+      .mapWithIndex {
+        case (_, index) =>
+          val helper = new ItemAnswersHelper(userAnswers, equipmentIndex, index)
+          Seq(helper.transportEquipmentItem).flatten
+      }
+      .toList match {
+      case Nil => None
+      case rows =>
+        Some(
+          AccordionSection(
+            sectionTitle = Some("Items that this transport equipment applies to"),
+            rows = rows.flatten,
+            id = Some(s"transport-equipment-$equipmentIndex-items"),
+            viewLinks = Seq(itemsAddRemoveLink(equipmentIndex))
+          )
+        )
     }
+
+  private def sealsAddRemoveLink(index: Index): Link =
+    Link(
+      id = s"add-remove-seals-${index.display}",
+      href = controllers.transportEquipment.index.routes.AddAnotherSealController.onPageLoad(arrivalId, NormalMode, index).url,
+      text = messages("sealsLink.addRemove"),
+      visuallyHidden = messages("sealsLink.visuallyHidden")
+    )
+
+  private def itemsAddRemoveLink(index: Index): Link =
+    Link(
+      id = s"add-remove-consignment-items-${index.display}",
+      href = controllers.transportEquipment.index.routes.ApplyAnotherItemController.onPageLoad(arrivalId, NormalMode, index).url,
+      text = messages("consignmentItemLink.addRemove", index.display),
+      visuallyHidden = messages("consignmentItemLink.visuallyHidden", index.display)
+    )
 }

--- a/app/utils/answersHelpers/consignment/TransportEquipmentAnswersHelper.scala
+++ b/app/utils/answersHelpers/consignment/TransportEquipmentAnswersHelper.scala
@@ -55,7 +55,7 @@ class TransportEquipmentAnswersHelper(
       case rows =>
         Some(
           AccordionSection(
-            sectionTitle = Some("Seals"),
+            sectionTitle = Some(messages("unloadingFindings.subsections.seals")),
             rows = rows.flatten,
             id = Some(s"transport-equipment-$equipmentIndex-seals"),
             viewLinks = Seq(sealsAddRemoveLink(equipmentIndex))
@@ -76,7 +76,7 @@ class TransportEquipmentAnswersHelper(
       case rows =>
         Some(
           AccordionSection(
-            sectionTitle = Some("Items that this transport equipment applies to"),
+            sectionTitle = Some(messages("unloadingFindings.subsections.goodsReferences")),
             rows = rows.flatten,
             id = Some(s"transport-equipment-$equipmentIndex-items"),
             viewLinks = Seq(itemsAddRemoveLink(equipmentIndex))

--- a/app/utils/answersHelpers/consignment/houseConsignment/ConsignmentItemAnswersHelper.scala
+++ b/app/utils/answersHelpers/consignment/houseConsignment/ConsignmentItemAnswersHelper.scala
@@ -258,7 +258,7 @@ class ConsignmentItemAnswersHelper(
 
   private[consignment] def packagingAddRemoveLink: Link =
     Link(
-      id = s"add-remove-packaging",
+      id = s"add-remove-item-$itemIndex-packaging",
       href = "#",
       text = messages("packagingLink.addRemove"),
       visuallyHidden = messages("packagingLink.visuallyHidden")
@@ -266,7 +266,7 @@ class ConsignmentItemAnswersHelper(
 
   private[consignment] def documentAddRemoveLink: Link =
     Link(
-      id = s"add-remove-document",
+      id = s"add-remove-item-$itemIndex-document",
       href = "#",
       text = messages("documentLink.addRemove"),
       visuallyHidden = messages("documentLink.visuallyHidden")
@@ -274,7 +274,7 @@ class ConsignmentItemAnswersHelper(
 
   private[consignment] def additionalReferenceAddRemoveLink: Link =
     Link(
-      id = s"add-remove-additionalReference",
+      id = s"add-remove-item-$itemIndex-additional-reference",
       href = "#",
       text = messages("additionalReferenceLink.addRemove"),
       visuallyHidden = messages("additionalReferenceLink.visuallyHidden")

--- a/app/utils/answersHelpers/consignment/transportEquipment/SealAnswersHelper.scala
+++ b/app/utils/answersHelpers/consignment/transportEquipment/SealAnswersHelper.scala
@@ -16,6 +16,7 @@
 
 package utils.answersHelpers.consignment.transportEquipment
 
+import controllers.transportEquipment.index.seals.routes
 import models.{CheckMode, Index, UserAnswers}
 import pages.transportEquipment.index.seals.SealIdentificationNumberPage
 import play.api.i18n.Messages
@@ -35,7 +36,6 @@ class SealAnswersHelper(
     prefix = "unloadingFindings.rowHeadings.sealIdentifier",
     args = Seq(sealIndex.display, equipmentIndex.display): _*,
     id = Some(s"change-seal-details-${equipmentIndex.display}-${sealIndex.display}"),
-    call =
-      Some(controllers.transportEquipment.index.seals.routes.SealIdentificationNumberController.onPageLoad(arrivalId, CheckMode, equipmentIndex, sealIndex))
+    call = Some(routes.SealIdentificationNumberController.onPageLoad(arrivalId, CheckMode, equipmentIndex, sealIndex))
   )
 }

--- a/app/viewModels/sections/Section.scala
+++ b/app/viewModels/sections/Section.scala
@@ -25,7 +25,6 @@ sealed trait Section {
   val children: Seq[Section]
   val viewLinks: Seq[Link]
   val id: Option[String]
-  val optionalInformationHeading: Option[String]
 }
 
 object Section {
@@ -35,8 +34,7 @@ object Section {
     rows: Seq[SummaryListRow] = Nil,
     children: Seq[Section] = Nil,
     viewLinks: Seq[Link] = Nil,
-    id: Option[String] = None,
-    optionalInformationHeading: Option[String] = None
+    id: Option[String] = None
   ) extends Section
 
   object AccordionSection {
@@ -55,8 +53,7 @@ object Section {
     sectionTitle: Option[String] = None,
     rows: Seq[SummaryListRow] = Nil,
     viewLinks: Seq[Link] = Nil,
-    id: Option[String] = None,
-    optionalInformationHeading: Option[String] = None
+    id: Option[String] = None
   ) extends Section {
 
     override val children: Seq[Section] = Seq.empty
@@ -66,8 +63,5 @@ object Section {
 
     def apply(sectionTitle: String, rows: Seq[SummaryListRow]): StaticSection =
       new StaticSection(sectionTitle = Some(sectionTitle), rows = rows)
-
-    def apply(sectionTitle: String, rows: Seq[SummaryListRow], optionalInformationHeading: String): StaticSection =
-      new StaticSection(sectionTitle = Some(sectionTitle), rows = rows, optionalInformationHeading = Some(optionalInformationHeading))
   }
 }

--- a/app/views/components/AnswerSection.scala.html
+++ b/app/views/components/AnswerSection.scala.html
@@ -69,15 +69,13 @@
 
 @content = {
     @if(section.rows.nonEmpty) {
-        <dl class="govuk-summary-list">
-            @govukSummaryList(
-                SummaryList(
-                    rows = section.rows
-                )
+        @govukSummaryList(
+            SummaryList(
+                rows = section.rows
             )
-        </dl>
+        )
     } else if(section.children.isEmpty) {
-        <p class="govuk-body">Some content here explaining that user has answered NO to everything</p>
+        <p class="govuk-body">@messages("unloadingFindings.noInformationProvided")</p>
     }
 
     @section.children.map(this(_, nestingLevel + 1))

--- a/app/views/components/AnswerSection.scala.html
+++ b/app/views/components/AnswerSection.scala.html
@@ -31,10 +31,6 @@
             <h2 class="govuk-heading-m">@title</h2>
         }
 
-        @section.optionalInformationHeading.map { heading =>
-            <h3 class="govuk-heading-s">@heading</h3>
-        }
-
         @if(section.rows.nonEmpty) {
             @govukSummaryList(
                 SummaryList(
@@ -80,6 +76,8 @@
                 )
             )
         </dl>
+    } else if(section.children.isEmpty) {
+        <p class="govuk-body">Some content here explaining that user has answered NO to everything</p>
     }
 
     @section.children.map(this(_, nestingLevel + 1))

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -27,6 +27,7 @@ site.email.link = If you have any questions or issues, email us at {0}
 site.email.subject = NCTS Phase 5 - Help with testing
 
 unloadingFindings.sequenceNumber = Sequence number
+unloadingFindings.noInformationProvided = No information provided
 
 error.title.prefix = Error:
 error.summary.title = There is a problem
@@ -462,6 +463,8 @@ unloadingFindings.rowHeadings.vehicleNationality.change.hidden = registered coun
 
 unloadingFindings.subsections.transportEquipment = Transport equipment {0}
 unloadingFindings.subsections.transportEquipment.parent.heading = Transport equipment
+unloadingFindings.subsections.seals = Seals
+unloadingFindings.subsections.goodsReferences = Items applied to this transport equipment
 unloadingFindings.rowHeadings.containerIdentificationNumber = Container identification number
 unloadingFindings.rowHeadings.incident.item = Goods item number {0}
 unloadingFindings.rowHeadings.sealIdentifier = Seal {0}

--- a/test/utils/answersHelpers/ConsignmentAnswersHelperSpec.scala
+++ b/test/utils/answersHelpers/ConsignmentAnswersHelperSpec.scala
@@ -283,18 +283,21 @@ class ConsignmentAnswersHelperSpec extends AnswersHelperSpecBase {
 
             result.children.head mustBe a[AccordionSection]
             result.children.head.sectionTitle.value mustBe "Transport equipment 1"
-            result.children.head.children.head mustBe a[StaticSection]
-            result.children.head.children.head.rows.size mustBe 2
-            result.children.head.children.head.rows.head.value.value mustBe containerId
-            result.children.head.children.head.rows(1).value.value mustBe sealId
+
+            result.children.head.rows.size mustBe 1
+            result.children.head.rows.head.value.value mustBe containerId
+
+            result.children.head.children.head mustBe a[AccordionSection]
+            result.children.head.children.head.rows.size mustBe 1
+            result.children.head.children.head.rows.head.value.value mustBe sealId
             result.children.head.children.head.viewLinks.head.href mustBe
               controllers.transportEquipment.index.routes.AddAnotherSealController.onPageLoad(arrivalId, NormalMode, equipmentIndex).url
-            result.children.head.children(1) mustBe a[StaticSection]
+
+            result.children.head.children(1) mustBe a[AccordionSection]
             result.children.head.children(1).rows.size mustBe 1
             result.children.head.children(1).rows.head.value.value mustBe item.toString
             result.children.head.children(1).viewLinks.head.href mustBe
               controllers.transportEquipment.index.routes.ApplyAnotherItemController.onPageLoad(arrivalId, NormalMode, index).url
-            result.children.head.children(1).optionalInformationHeading mustBe Some("Which items does this transport equipment apply to?")
         }
       }
     }

--- a/test/utils/answersHelpers/consignment/TransportEquipmentAnswersHelperSpec.scala
+++ b/test/utils/answersHelpers/consignment/TransportEquipmentAnswersHelperSpec.scala
@@ -76,6 +76,10 @@ class TransportEquipmentAnswersHelperSpec extends AnswersHelperSpecBase {
             result.sectionTitle.value mustBe "Seals"
             result.id.value mustBe "transport-equipment-1-seals"
 
+            val addOrRemove = result.viewLinks.head
+            addOrRemove.id mustBe "add-remove-transport-equipment-1-seal"
+            addOrRemove.text mustBe "Add or remove seal"
+
             result.rows.size mustBe 2
             result.rows.head.value.value mustBe value1
             result.rows(1).value.value mustBe value2
@@ -97,6 +101,10 @@ class TransportEquipmentAnswersHelperSpec extends AnswersHelperSpecBase {
             result mustBe a[AccordionSection]
             result.sectionTitle.value mustBe "Items applied to this transport equipment"
             result.id.value mustBe "transport-equipment-1-items"
+
+            val addOrRemove = result.viewLinks.head
+            addOrRemove.id mustBe "add-remove-transport-equipment-1-item"
+            addOrRemove.text mustBe "Add or remove items from transport equipment 1"
 
             result.rows.size mustBe 2
             result.rows.head.value.value mustBe item1.toString

--- a/test/utils/answersHelpers/consignment/TransportEquipmentAnswersHelperSpec.scala
+++ b/test/utils/answersHelpers/consignment/TransportEquipmentAnswersHelperSpec.scala
@@ -18,12 +18,13 @@ package utils.answersHelpers.consignment
 
 import models.reference.Item
 import models.{CheckMode, Index}
-import org.scalacheck.Gen
 import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
 import pages.ContainerIdentificationNumberPage
 import pages.transportEquipment.index.ItemPage
 import pages.transportEquipment.index.seals.SealIdentificationNumberPage
 import utils.answersHelpers.AnswersHelperSpecBase
+import viewModels.sections.Section.AccordionSection
 
 class TransportEquipmentAnswersHelperSpec extends AnswersHelperSpecBase {
 
@@ -61,7 +62,7 @@ class TransportEquipmentAnswersHelperSpec extends AnswersHelperSpecBase {
     }
 
     "transportEquipmentSeals" - {
-      "must generate row for each seal" in {
+      "must generate accordion section" in {
         forAll(Gen.alphaNumStr, Gen.alphaNumStr) {
           (value1, value2) =>
             val answers = emptyUserAnswers
@@ -69,17 +70,21 @@ class TransportEquipmentAnswersHelperSpec extends AnswersHelperSpecBase {
               .setValue(SealIdentificationNumberPage(equipmentIndex, Index(1)), value2)
 
             val helper = new TransportEquipmentAnswersHelper(answers, equipmentIndex)
-            val result = helper.transportEquipmentSeals
+            val result = helper.transportEquipmentSeals.value
 
-            result.size mustBe 2
-            result.head.value.value mustBe value1
-            result(1).value.value mustBe value2
+            result mustBe a[AccordionSection]
+            result.sectionTitle.value mustBe "Seals"
+            result.id.value mustBe "transport-equipment-1-seals"
+
+            result.rows.size mustBe 2
+            result.rows.head.value.value mustBe value1
+            result.rows(1).value.value mustBe value2
         }
       }
     }
 
     "transportEquipmentItems" - {
-      "must generate row for each consignment item" in {
+      "must generate accordion section" in {
         forAll(arbitrary[Item].sample.value, arbitrary[Item].sample.value) {
           (item1, item2) =>
             val answers = emptyUserAnswers
@@ -87,11 +92,15 @@ class TransportEquipmentAnswersHelperSpec extends AnswersHelperSpecBase {
               .setValue(ItemPage(equipmentIndex, Index(1)), item2)
 
             val helper = new TransportEquipmentAnswersHelper(answers, equipmentIndex)
-            val result = helper.transportEquipmentItems
+            val result = helper.transportEquipmentItems.value
 
-            result.size mustBe 2
-            result.head.value.value mustBe item1.toString
-            result(1).value.value mustBe item2.toString
+            result mustBe a[AccordionSection]
+            result.sectionTitle.value mustBe "Items applied to this transport equipment"
+            result.id.value mustBe "transport-equipment-1-items"
+
+            result.rows.size mustBe 2
+            result.rows.head.value.value mustBe item1.toString
+            result.rows(1).value.value mustBe item2.toString
         }
       }
     }

--- a/test/utils/answersHelpers/consignment/houseConsignment/ConsignmentItemAnswersHelperSpec.scala
+++ b/test/utils/answersHelpers/consignment/houseConsignment/ConsignmentItemAnswersHelperSpec.scala
@@ -305,6 +305,10 @@ class ConsignmentItemAnswersHelperSpec extends AnswersHelperSpecBase {
             result.sectionTitle.value mustBe "Documents"
             result.id.value mustBe "item-1-documents"
 
+            val addOrRemove = result.viewLinks.head
+            addOrRemove.id mustBe "add-remove-item-1-document"
+            addOrRemove.text mustBe "Add or remove document"
+
             result.children.head mustBe a[AccordionSection]
             result.children.head.sectionTitle.value mustBe "Document 1"
             result.children.head.id.value mustBe "item-1-document-1"

--- a/test/viewModels/HouseConsignmentViewModelSpec.scala
+++ b/test/viewModels/HouseConsignmentViewModelSpec.scala
@@ -120,7 +120,7 @@ class HouseConsignmentViewModelSpec extends SpecBase with AppWithDefaultMockFixt
 
         result.sections.head.children.head.children(1) mustBe a[StaticSection]
         result.sections.head.children.head.children(1).sectionTitle.value mustBe "Documents"
-        result.sections.head.children.head.children(1).viewLinks.head.id mustBe "add-remove-document"
+        result.sections.head.children.head.children(1).viewLinks.head.id mustBe "add-remove-item-1-document"
 
       }
     }

--- a/test/viewModels/UnloadingFindingsViewModelSpec.scala
+++ b/test/viewModels/UnloadingFindingsViewModelSpec.scala
@@ -22,8 +22,6 @@ import generators.Generators
 import models.departureTransportMeans.TransportMeansIdentification
 import models.reference._
 import models.{Index, SecurityType, UserAnswers}
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import pages._
@@ -35,28 +33,12 @@ import pages.houseConsignment.index.items.{GrossWeightPage, ItemDescriptionPage,
 import pages.incident.{IncidentCodePage, IncidentTextPage}
 import pages.transportEquipment.index.ItemPage
 import pages.transportEquipment.index.seals.SealIdentificationNumberPage
-import play.api.inject.bind
-import play.api.inject.guice.GuiceApplicationBuilder
 import scalaxb.XMLCalendar
-import services.ReferenceDataService
 import viewModels.UnloadingFindingsViewModel.UnloadingFindingsViewModelProvider
-
-import scala.Nil
-import scala.concurrent.Future
 
 class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFixtures with ScalaCheckPropertyChecks with Generators {
 
-  val mockReferenceDataService: ReferenceDataService = mock[ReferenceDataService]
-  private val countryDesc                            = "Great Britain"
-
-  override def guiceApplicationBuilder(): GuiceApplicationBuilder =
-    super
-      .guiceApplicationBuilder()
-      .overrides(bind[ReferenceDataService].toInstance(mockReferenceDataService))
-
   "Unloading findings sections" - {
-
-    val customsOffice = CustomsOffice("id", "name", "countryId", None)
 
     "must render header section" in {
       val viewModelProvider = new UnloadingFindingsViewModelProvider()
@@ -69,6 +51,8 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
           )
         )
       )
+
+      val customsOffice = CustomsOffice("id", "name", "countryId", None)
 
       val result = viewModelProvider.apply(
         userAnswers
@@ -163,12 +147,7 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
               )
             )
           )
-          .setValue(CustomsOfficeOfDestinationActualPage, customsOffice)
           .setValue(HotPCountryPage, country)
-
-        setExistingUserAnswers(userAnswers)
-
-        when(mockReferenceDataService.getCountryByCode(any())(any(), any())).thenReturn(Future.successful(country))
 
         val viewModelProvider = new UnloadingFindingsViewModelProvider()
         val result            = viewModelProvider.apply(userAnswers)
@@ -182,10 +161,6 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
       "when there is none" in {
         val userAnswers = emptyUserAnswers
           .copy(ie043Data = basicIe043.copy(HolderOfTheTransitProcedure = None))
-          .setValue(CustomsOfficeOfDestinationActualPage, customsOffice)
-
-        setExistingUserAnswers(userAnswers)
-        when(mockReferenceDataService.getCountryNameByCode(any())(any(), any())).thenReturn(Future.successful(countryDesc))
 
         val viewModelProvider = new UnloadingFindingsViewModelProvider()
         val result            = viewModelProvider.apply(userAnswers)
@@ -201,11 +176,6 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
         .setValue(TransportMeansIdentificationPage(dtmIndex), TransportMeansIdentification("4", ""))
         .setValue(VehicleIdentificationNumberPage(dtmIndex), "28")
         .setValue(CountryPage(dtmIndex), Country("GB", ""))
-        .setValue(CustomsOfficeOfDestinationActualPage, customsOffice)
-
-      setExistingUserAnswers(userAnswers)
-
-      when(mockReferenceDataService.getCountryNameByCode(any())(any(), any())).thenReturn(Future.successful(countryDesc))
 
       val viewModelProvider = new UnloadingFindingsViewModelProvider()
       val result            = viewModelProvider.apply(userAnswers)
@@ -228,13 +198,6 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
         .setValue(TransportMeansIdentificationPage(Index(1)), TransportMeansIdentification("4", ""))
         .setValue(VehicleIdentificationNumberPage(Index(1)), "28")
         .setValue(CountryPage(Index(1)), Country("GB", ""))
-        .setValue(CustomsOfficeOfDestinationActualPage, customsOffice)
-
-      setExistingUserAnswers(userAnswers)
-      when(mockReferenceDataService.getCountryNameByCode(any())(any(), any())).thenReturn(Future.successful(countryDesc))
-      setExistingUserAnswers(userAnswers)
-
-      when(mockReferenceDataService.getCountryNameByCode(any())(any(), any())).thenReturn(Future.successful(countryDesc))
 
       val viewModelProvider = new UnloadingFindingsViewModelProvider()
       val result            = viewModelProvider.apply(userAnswers)
@@ -259,10 +222,6 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
         "with no seals" in {
           val userAnswers = emptyUserAnswers
             .setValue(ContainerIdentificationNumberPage(equipmentIndex), "cin-1")
-            .setValue(CustomsOfficeOfDestinationActualPage, customsOffice)
-
-          setExistingUserAnswers(userAnswers)
-          when(mockReferenceDataService.getCountryNameByCode(any())(any(), any())).thenReturn(Future.successful(countryDesc))
 
           val viewModelProvider = new UnloadingFindingsViewModelProvider()
           val result            = viewModelProvider.apply(userAnswers)
@@ -273,25 +232,15 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
           section.children.length mustBe 1
 
           section.children.head.sectionTitle.value mustBe "Transport equipment 1"
-          section.children.head.rows.size mustBe 0
+          section.children.head.rows.size mustBe 1
           section.children.head.viewLinks mustBe Nil
-
-          section.children.head.children.size mustBe 2
-
-          section.children.head.children.head.sectionTitle mustBe None
-          section.children.head.children.head.rows.size mustBe 1
-          section.children.head.children.head.viewLinks must not be Nil
-          section.children.head.children.head.optionalInformationHeading mustBe None
+          section.children.head.children.size mustBe 0
         }
 
         "with seals" in {
           val userAnswers = emptyUserAnswers
             .setValue(ContainerIdentificationNumberPage(equipmentIndex), "cin-1")
             .setValue(SealIdentificationNumberPage(equipmentIndex, sealIndex), "1002")
-            .setValue(CustomsOfficeOfDestinationActualPage, customsOffice)
-
-          setExistingUserAnswers(userAnswers)
-          when(mockReferenceDataService.getCountryNameByCode(any())(any(), any())).thenReturn(Future.successful(countryDesc))
 
           val viewModelProvider = new UnloadingFindingsViewModelProvider()
           val result            = viewModelProvider.apply(userAnswers)
@@ -302,15 +251,14 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
           section.children.length mustBe 1
 
           section.children.head.sectionTitle.value mustBe "Transport equipment 1"
-          section.children.head.rows.size mustBe 0
+          section.children.head.rows.size mustBe 1
           section.children.head.viewLinks mustBe Nil
+          section.children.head.children.size mustBe 1
 
-          section.children.head.children.size mustBe 2
-
-          section.children.head.children.head.sectionTitle mustBe None
-          section.children.head.children.head.rows.size mustBe 2
-          section.children.head.children.head.viewLinks must not be Nil
-          section.children.head.children.head.optionalInformationHeading mustBe None
+          val seals = section.children.head.children.head
+          seals.sectionTitle.value mustBe "Seals"
+          seals.rows.size mustBe 1
+          seals.viewLinks must not be Nil
         }
       }
       "when there is multiple" - {
@@ -319,10 +267,6 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
           val userAnswers = emptyUserAnswers
             .setValue(ContainerIdentificationNumberPage(Index(0)), "cin-1")
             .setValue(ContainerIdentificationNumberPage(Index(1)), "cin-1")
-            .setValue(CustomsOfficeOfDestinationActualPage, customsOffice)
-
-          setExistingUserAnswers(userAnswers)
-          when(mockReferenceDataService.getCountryNameByCode(any())(any(), any())).thenReturn(Future.successful(countryDesc))
 
           val viewModelProvider = new UnloadingFindingsViewModelProvider()
           val result            = viewModelProvider.apply(userAnswers)
@@ -333,24 +277,14 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
           section.children.length mustBe 2
 
           section.children.head.sectionTitle.value mustBe "Transport equipment 1"
-          section.children.head.rows.size mustBe 0
+          section.children.head.rows.size mustBe 1
           section.children.head.viewLinks mustBe Nil
-
-          section.children.head.children.size mustBe 2
-
-          section.children.head.children.head.sectionTitle mustBe None
-          section.children.head.children.head.rows.size mustBe 1
-          section.children.head.children.head.viewLinks must not be Nil
-          section.children.head.children.head.optionalInformationHeading mustBe None
+          section.children.head.children.size mustBe 0
 
           section.children(1).sectionTitle.value mustBe "Transport equipment 2"
-          section.children(1).rows.size mustBe 0
+          section.children(1).rows.size mustBe 1
           section.children(1).viewLinks mustBe Nil
-
-          section.children(1).children.head.sectionTitle mustBe None
-          section.children(1).children.head.rows.size mustBe 1
-          section.children(1).children.head.viewLinks must not be Nil
-          section.children(1).children.head.optionalInformationHeading mustBe None
+          section.children.head.children.size mustBe 0
         }
 
         "with seals" in {
@@ -359,10 +293,6 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
             .setValue(SealIdentificationNumberPage(Index(0), sealIndex), "1002")
             .setValue(ContainerIdentificationNumberPage(Index(1)), "cin-1")
             .setValue(SealIdentificationNumberPage(Index(1), sealIndex), "1002")
-            .setValue(CustomsOfficeOfDestinationActualPage, customsOffice)
-
-          setExistingUserAnswers(userAnswers)
-          when(mockReferenceDataService.getCountryNameByCode(any())(any(), any())).thenReturn(Future.successful(countryDesc))
 
           val viewModelProvider = new UnloadingFindingsViewModelProvider()
           val result            = viewModelProvider.apply(userAnswers)
@@ -372,24 +302,24 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
           section.children.length mustBe 2
 
           section.children.head.sectionTitle.value mustBe "Transport equipment 1"
-          section.children.head.rows.size mustBe 0
+          section.children.head.rows.size mustBe 1
           section.children.head.viewLinks mustBe Nil
+          section.children.head.children.size mustBe 1
 
-          section.children.head.children.size mustBe 2
-
-          section.children.head.children.head.sectionTitle mustBe None
-          section.children.head.children.head.rows.size mustBe 2
-          section.children.head.children.head.viewLinks must not be Nil
-          section.children.head.children.head.optionalInformationHeading mustBe None
+          val transportEquipment1Seals = section.children.head.children.head
+          transportEquipment1Seals.sectionTitle.value mustBe "Seals"
+          transportEquipment1Seals.rows.size mustBe 1
+          transportEquipment1Seals.viewLinks must not be Nil
 
           section.children(1).sectionTitle.value mustBe "Transport equipment 2"
-          section.children(1).rows.size mustBe 0
+          section.children(1).rows.size mustBe 1
           section.children(1).viewLinks mustBe Nil
+          section.children(1).children.size mustBe 1
 
-          section.children(1).children.head.sectionTitle mustBe None
-          section.children(1).children.head.rows.size mustBe 2
-          section.children(1).children.head.viewLinks must not be Nil
-          section.children(1).children.head.optionalInformationHeading mustBe None
+          val transportEquipment2Seals = section.children(1).children.head
+          transportEquipment2Seals.sectionTitle.value mustBe "Seals"
+          transportEquipment2Seals.rows.size mustBe 1
+          transportEquipment2Seals.viewLinks must not be Nil
         }
       }
 
@@ -399,10 +329,6 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
           val userAnswers = emptyUserAnswers
             .setValue(ContainerIdentificationNumberPage(equipmentIndex), "cin-1")
             .setValue(SealIdentificationNumberPage(equipmentIndex, sealIndex), "1002")
-            .setValue(CustomsOfficeOfDestinationActualPage, customsOffice)
-
-          setExistingUserAnswers(userAnswers)
-          when(mockReferenceDataService.getCountryNameByCode(any())(any(), any())).thenReturn(Future.successful(countryDesc))
 
           val viewModelProvider = new UnloadingFindingsViewModelProvider()
           val result            = viewModelProvider.apply(userAnswers)
@@ -413,26 +339,21 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
           section.children.length mustBe 1
 
           section.children.head.sectionTitle.value mustBe "Transport equipment 1"
-          section.children.head.rows.size mustBe 0
+          section.children.head.rows.size mustBe 1
           section.children.head.viewLinks mustBe Nil
+          section.children.head.children.size mustBe 1
 
-          section.children.head.children.size mustBe 2
-
-          section.children.head.children.head.sectionTitle mustBe None
-          section.children.head.children.head.rows.size mustBe 2
-          section.children.head.children.head.viewLinks must not be Nil
-          section.children.head.children.head.optionalInformationHeading mustBe None
+          val seals = section.children.head.children.head
+          seals.sectionTitle.value mustBe "Seals"
+          seals.rows.size mustBe 1
+          seals.viewLinks must not be Nil
         }
 
         "with items" in {
           val userAnswers = emptyUserAnswers
             .setValue(ContainerIdentificationNumberPage(equipmentIndex), "cin-1")
             .setValue(SealIdentificationNumberPage(equipmentIndex, sealIndex), "1002")
-            .setValue(CustomsOfficeOfDestinationActualPage, customsOffice)
             .setValue(ItemPage(equipmentIndex, itemIndex), Item(10, "12345"))
-
-          setExistingUserAnswers(userAnswers)
-          when(mockReferenceDataService.getCountryNameByCode(any())(any(), any())).thenReturn(Future.successful(countryDesc))
 
           val viewModelProvider = new UnloadingFindingsViewModelProvider()
           val result            = viewModelProvider.apply(userAnswers)
@@ -443,20 +364,20 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
           section.children.length mustBe 1
 
           section.children.head.sectionTitle.value mustBe "Transport equipment 1"
-          section.children.head.rows.size mustBe 0
+          section.children.head.rows.size mustBe 1
           section.children.head.viewLinks mustBe Nil
 
           section.children.head.children.size mustBe 2
 
-          section.children.head.children.head.sectionTitle mustBe None
-          section.children.head.children.head.rows.size mustBe 2
-          section.children.head.children.head.viewLinks must not be Nil
-          section.children.head.children.head.optionalInformationHeading mustBe None
+          val seals = section.children.head.children.head
+          seals.sectionTitle.value mustBe "Seals"
+          seals.rows.size mustBe 1
+          seals.viewLinks must not be Nil
 
-          section.children.head.children(1).sectionTitle mustBe None
-          section.children.head.children(1).rows.size mustBe 1
-          section.children.head.children(1).viewLinks must not be Nil
-          section.children.head.children(1).optionalInformationHeading must not be None
+          val goodsReferences = section.children.head.children(1)
+          goodsReferences.sectionTitle.value mustBe "Items applied to this transport equipment"
+          goodsReferences.rows.size mustBe 1
+          goodsReferences.viewLinks must not be Nil
         }
       }
       "when there is multiple" - {
@@ -467,10 +388,6 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
             .setValue(SealIdentificationNumberPage(Index(0), sealIndex), "1002")
             .setValue(ContainerIdentificationNumberPage(Index(1)), "cin-1")
             .setValue(SealIdentificationNumberPage(Index(1), sealIndex), "1002")
-            .setValue(CustomsOfficeOfDestinationActualPage, customsOffice)
-
-          setExistingUserAnswers(userAnswers)
-          when(mockReferenceDataService.getCountryNameByCode(any())(any(), any())).thenReturn(Future.successful(countryDesc))
 
           val viewModelProvider = new UnloadingFindingsViewModelProvider()
           val result            = viewModelProvider.apply(userAnswers)
@@ -480,38 +397,34 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
           section.children.length mustBe 2
 
           section.children.head.sectionTitle.value mustBe "Transport equipment 1"
-          section.children.head.rows.size mustBe 0
+          section.children.head.rows.size mustBe 1
           section.children.head.viewLinks mustBe Nil
+          section.children.head.children.size mustBe 1
 
-          section.children.head.children.size mustBe 2
-
-          section.children.head.children.head.sectionTitle mustBe None
-          section.children.head.children.head.rows.size mustBe 2
-          section.children.head.children.head.viewLinks must not be Nil
-          section.children.head.children.head.optionalInformationHeading mustBe None
+          val transportEquipment1Seals = section.children.head.children.head
+          transportEquipment1Seals.sectionTitle.value mustBe "Seals"
+          transportEquipment1Seals.rows.size mustBe 1
+          transportEquipment1Seals.viewLinks must not be Nil
 
           section.children(1).sectionTitle.value mustBe "Transport equipment 2"
-          section.children(1).rows.size mustBe 0
+          section.children(1).rows.size mustBe 1
           section.children(1).viewLinks mustBe Nil
+          section.children(1).children.size mustBe 1
 
-          section.children(1).children.head.sectionTitle mustBe None
-          section.children(1).children.head.rows.size mustBe 2
-          section.children(1).children.head.viewLinks must not be Nil
-          section.children(1).children.head.optionalInformationHeading mustBe None
+          val transportEquipment2Seals = section.children(1).children.head
+          transportEquipment2Seals.sectionTitle.value mustBe "Seals"
+          transportEquipment2Seals.rows.size mustBe 1
+          transportEquipment2Seals.viewLinks must not be Nil
         }
 
         "with items" in {
           val userAnswers = emptyUserAnswers
             .setValue(ContainerIdentificationNumberPage(Index(0)), "cin-1")
-            .setValue(SealIdentificationNumberPage(Index(0), sealIndex), "1002")
-            .setValue(ItemPage(equipmentIndex, Index(0)), Item(10, "12345"))
+            .setValue(SealIdentificationNumberPage(Index(0), Index(0)), "1002")
+            .setValue(ItemPage(Index(0), Index(0)), Item(10, "12345"))
             .setValue(ContainerIdentificationNumberPage(Index(1)), "cin-1")
-            .setValue(SealIdentificationNumberPage(Index(1), sealIndex), "1002")
-            .setValue(CustomsOfficeOfDestinationActualPage, customsOffice)
-            .setValue(ItemPage(equipmentIndex, Index(1)), Item(10, "12345"))
-
-          setExistingUserAnswers(userAnswers)
-          when(mockReferenceDataService.getCountryNameByCode(any())(any(), any())).thenReturn(Future.successful(countryDesc))
+            .setValue(SealIdentificationNumberPage(Index(1), Index(0)), "1002")
+            .setValue(ItemPage(Index(1), Index(0)), Item(10, "12345"))
 
           val viewModelProvider = new UnloadingFindingsViewModelProvider()
           val result            = viewModelProvider.apply(userAnswers)
@@ -521,34 +434,34 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
           section.children.length mustBe 2
 
           section.children.head.sectionTitle.value mustBe "Transport equipment 1"
-          section.children.head.rows.size mustBe 0
+          section.children.head.rows.size mustBe 1
           section.children.head.viewLinks mustBe Nil
-
           section.children.head.children.size mustBe 2
 
-          section.children.head.children.head.sectionTitle mustBe None
-          section.children.head.children.head.rows.size mustBe 2
-          section.children.head.children.head.viewLinks must not be Nil
-          section.children.head.children.head.optionalInformationHeading mustBe None
+          val transportEquipment1Seals = section.children.head.children.head
+          transportEquipment1Seals.sectionTitle.value mustBe "Seals"
+          transportEquipment1Seals.rows.size mustBe 1
+          transportEquipment1Seals.viewLinks must not be Nil
 
-          section.children.head.children(1).sectionTitle mustBe None
-          section.children.head.children(1).rows.size mustBe 2
-          section.children.head.children(1).viewLinks must not be Nil
-          section.children.head.children(1).optionalInformationHeading must not be None
+          val transportEquipment1GoodsReferences = section.children.head.children(1)
+          transportEquipment1GoodsReferences.sectionTitle.value mustBe "Items applied to this transport equipment"
+          transportEquipment1GoodsReferences.rows.size mustBe 1
+          transportEquipment1GoodsReferences.viewLinks must not be Nil
 
           section.children(1).sectionTitle.value mustBe "Transport equipment 2"
-          section.children(1).rows.size mustBe 0
+          section.children(1).rows.size mustBe 1
           section.children(1).viewLinks mustBe Nil
+          section.children.head.children.size mustBe 2
 
-          section.children(1).children.head.sectionTitle mustBe None
-          section.children(1).children.head.rows.size mustBe 2
-          section.children(1).children.head.viewLinks must not be Nil
-          section.children(1).children.head.optionalInformationHeading mustBe None
+          val transportEquipment2Seals = section.children(1).children.head
+          transportEquipment2Seals.sectionTitle.value mustBe "Seals"
+          transportEquipment2Seals.rows.size mustBe 1
+          transportEquipment2Seals.viewLinks must not be Nil
 
-          section.children.head.children(1).sectionTitle mustBe None
-          section.children.head.children(1).rows.size mustBe 2
-          section.children.head.children(1).viewLinks must not be Nil
-          section.children.head.children(1).optionalInformationHeading must not be None
+          val transportEquipment2GoodsReferences = section.children(1).children(1)
+          transportEquipment2GoodsReferences.sectionTitle.value mustBe "Items applied to this transport equipment"
+          transportEquipment2GoodsReferences.rows.size mustBe 1
+          transportEquipment2GoodsReferences.viewLinks must not be Nil
         }
       }
     }
@@ -566,10 +479,6 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
           .setValue(ItemDescriptionPage(hcIndex, itemIndex), "shirts")
           .setValue(GrossWeightPage(hcIndex, itemIndex), BigDecimal(123.45))
           .setValue(NetWeightPage(hcIndex, itemIndex), 123.45)
-          .setValue(CustomsOfficeOfDestinationActualPage, customsOffice)
-
-        setExistingUserAnswers(userAnswers)
-        when(mockReferenceDataService.getCountryNameByCode(any())(any(), any())).thenReturn(Future.successful(countryDesc))
 
         val viewModelProvider = new UnloadingFindingsViewModelProvider()
         val result            = viewModelProvider.apply(userAnswers)
@@ -607,10 +516,6 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
           .setValue(ItemDescriptionPage(Index(1), itemIndex), "shirts")
           .setValue(GrossWeightPage(Index(1), itemIndex), BigDecimal(123.45))
           .setValue(NetWeightPage(Index(1), itemIndex), 123.45)
-          .setValue(CustomsOfficeOfDestinationActualPage, customsOffice)
-
-        setExistingUserAnswers(userAnswers)
-        when(mockReferenceDataService.getCountryNameByCode(any())(any(), any())).thenReturn(Future.successful(countryDesc))
 
         val viewModelProvider = new UnloadingFindingsViewModelProvider()
         val result            = viewModelProvider.apply(userAnswers)
@@ -634,9 +539,6 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
         val userAnswers = emptyUserAnswers
           .setValue(AdditionalReferenceTypePage(index), AdditionalReferenceType("Y015", "The rough diamonds are contained in ..."))
           .setValue(AdditionalReferenceNumberPage(index), "addref-1")
-          .setValue(CustomsOfficeOfDestinationActualPage, customsOffice)
-
-        setExistingUserAnswers(userAnswers)
 
         val viewModelProvider = new UnloadingFindingsViewModelProvider()
         val result            = viewModelProvider.apply(userAnswers)
@@ -653,9 +555,6 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
           .setValue(AdditionalReferenceNumberPage(Index(0)), "addref-1")
           .setValue(AdditionalReferenceTypePage(Index(1)), AdditionalReferenceType("Y022", "Consignor / exporter (AEO certificate number)"))
           .setValue(AdditionalReferenceNumberPage(Index(1)), "addref-2")
-          .setValue(CustomsOfficeOfDestinationActualPage, customsOffice)
-
-        setExistingUserAnswers(userAnswers)
 
         val viewModelProvider = new UnloadingFindingsViewModelProvider()
         val result            = viewModelProvider.apply(userAnswers)
@@ -673,9 +572,6 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
         val userAnswers = emptyUserAnswers
           .setValue(AdditionalInformationCodePage(index), AdditionalInformationCode("20300", "Export"))
           .setValue(AdditionalInformationTextPage(index), "a string")
-          .setValue(CustomsOfficeOfDestinationActualPage, customsOffice)
-
-        setExistingUserAnswers(userAnswers)
 
         val viewModelProvider = new UnloadingFindingsViewModelProvider()
         val result            = viewModelProvider.apply(userAnswers)
@@ -698,9 +594,6 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
             )
           )
           .setValue(AdditionalInformationTextPage(Index(1)), "another string")
-          .setValue(CustomsOfficeOfDestinationActualPage, customsOffice)
-
-        setExistingUserAnswers(userAnswers)
 
         val viewModelProvider = new UnloadingFindingsViewModelProvider()
         val result            = viewModelProvider.apply(userAnswers)
@@ -717,9 +610,6 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
         val userAnswers = emptyUserAnswers
           .setValue(IncidentCodePage(index), Incident("1", "bad wrapping paper"))
           .setValue(IncidentTextPage(index), "it got wet")
-          .setValue(CustomsOfficeOfDestinationActualPage, customsOffice)
-
-        setExistingUserAnswers(userAnswers)
 
         val viewModelProvider = new UnloadingFindingsViewModelProvider()
         val result            = viewModelProvider.apply(userAnswers)
@@ -740,9 +630,6 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
           .setValue(IncidentTextPage(Index(0)), "free text 1")
           .setValue(IncidentCodePage(Index(1)), Incident("2", "desc 2"))
           .setValue(IncidentTextPage(Index(1)), "free text 2")
-          .setValue(CustomsOfficeOfDestinationActualPage, customsOffice)
-
-        setExistingUserAnswers(userAnswers)
 
         val viewModelProvider = new UnloadingFindingsViewModelProvider()
         val result            = viewModelProvider.apply(userAnswers)

--- a/test/views/UnloadingFindingsViewSpec.scala
+++ b/test/views/UnloadingFindingsViewSpec.scala
@@ -20,6 +20,7 @@ import generators.Generators
 import models.NormalMode
 import play.twirl.api.HtmlFormat
 import viewModels.UnloadingFindingsViewModel
+import viewModels.sections.Section.AccordionSection
 import views.behaviours.DetailsListViewBehaviours
 import views.html.UnloadingFindingsView
 
@@ -29,7 +30,7 @@ class UnloadingFindingsViewSpec extends DetailsListViewBehaviours with Generator
 
   override def view: HtmlFormat.Appendable = injector.instanceOf[UnloadingFindingsView].apply(mrn, arrivalId, unloadingFindingsViewModel)(fakeRequest, messages)
 
-  val unloadingFindingsViewModel: UnloadingFindingsViewModel = new UnloadingFindingsViewModel(sections)
+  private val unloadingFindingsViewModel: UnloadingFindingsViewModel = new UnloadingFindingsViewModel(sections)
 
   behave like pageWithTitle()
 
@@ -50,4 +51,16 @@ class UnloadingFindingsViewSpec extends DetailsListViewBehaviours with Generator
     })
   }
 
+  "must render 'No information provided' when rows and children are empty" in {
+    val accordionId                = "foo"
+    val sections                   = Seq(AccordionSection(rows = Nil, children = Nil, id = Some(accordionId)))
+    val unloadingFindingsViewModel = new UnloadingFindingsViewModel(sections)
+
+    val view = injector.instanceOf[UnloadingFindingsView].apply(mrn, arrivalId, unloadingFindingsViewModel)(fakeRequest, messages)
+
+    val doc       = parseView(view)
+    val accordion = doc.getElementById(accordionId)
+
+    accordion.text() mustBe "No information provided"
+  }
 }

--- a/test/views/behaviours/DetailsListViewBehaviours.scala
+++ b/test/views/behaviours/DetailsListViewBehaviours.scala
@@ -60,31 +60,31 @@ trait DetailsListViewBehaviours extends ViewBehaviours with Generators {
                     Text(value) mustBe row.value.content
                   }
 
-//                  row.actions match {
-//                    case None =>
-//                      "must not render any actions" in {
-//                        assert(renderedRow.getElementsByClass("govuk-summary-list__actions").isEmpty)
-//                      }
-//                    case Some(value) =>
-//                      val actions = renderedRow
-//                        .getElementsByClass("govuk-summary-list__actions")
-//                        .first()
-//                        .getElementsByClass("govuk-link")
-//
-//                      value.items.zipWithIndex.foreach {
-//                        case (item, itemIndex) =>
-//                          s"must contain action ${itemIndex + 1}" in {
-//                            assertElementExists(
-//                              actions,
-//                              element =>
-//                                element.attr("href") == item.href && (item.visuallyHiddenText match {
-//                                  case Some(value) => element.getElementsByClass("govuk-visually-hidden").text() == value
-//                                  case None        => Text(element.text()) == item.content
-//                                })
-//                            )
-//                          }
-//                      }
-//                  }
+                  row.actions match {
+                    case None =>
+                      "must not render any actions" in {
+                        assert(renderedRow.getElementsByClass("govuk-summary-list__actions").isEmpty)
+                      }
+                    case Some(value) =>
+                      val actions = renderedRow
+                        .getElementsByClass("govuk-summary-list__actions")
+                        .first()
+                        .getElementsByClass("govuk-link")
+
+                      value.items.zipWithIndex.foreach {
+                        case (item, itemIndex) =>
+                          s"must contain action ${itemIndex + 1}" in {
+                            assertElementExists(
+                              actions,
+                              element =>
+                                element.attr("href") == item.href && (item.visuallyHiddenText match {
+                                  case Some(value) => element.getElementsByClass("govuk-visually-hidden").text() == value
+                                  case None        => Text(element.text()) == item.content
+                                })
+                            )
+                          }
+                      }
+                  }
                 }
             }
           }


### PR DESCRIPTION
- Rendering "No information provided" when `rows` and `children` are both empty
- Moving seals and goods references into parent accordions

<img width="631" alt="Screenshot 2024-03-18 at 16 37 24" src="https://github.com/hmrc/manage-transit-movements-unloading-frontend/assets/43777106/b9b14629-0ed4-44b4-85ca-20886673edb0">
