### PR TITLE
CTCP-5131

### DIFF
--- a/app/utils/answersHelpers/AnswersHelper.scala
+++ b/app/utils/answersHelpers/AnswersHelper.scala
@@ -16,27 +16,16 @@
 
 package utils.answersHelpers
 
-import models.{ArrivalId, Index, RichOptionalJsArray, UserAnswers}
+import models.{ArrivalId, UserAnswers}
 import pages._
-import pages.sections.Section
 import play.api.i18n.Messages
 import play.api.libs.json._
 import play.api.mvc.Call
-import uk.gov.hmrc.govukfrontend.views.html.components.implicits._
 import uk.gov.hmrc.govukfrontend.views.html.components.{Content, SummaryListRow}
 
 class AnswersHelper(userAnswers: UserAnswers)(implicit messages: Messages) extends SummaryListRowHelper {
 
   def arrivalId: ArrivalId = userAnswers.id
-
-  def sequenceNumber(jsValue: JsValue): Option[SummaryListRow] =
-    jsValue.transform((__ \ "sequenceNumber").json.pick[JsString]).asOpt.map {
-      case JsString(value) =>
-        buildRowWithNoChangeLink(
-          prefix = messages("unloadingFindings.sequenceNumber"),
-          answer = value.toText
-        )
-    }
 
   def getAnswerAndBuildRow[T](
     page: QuestionPage[T],
@@ -102,12 +91,4 @@ class AnswersHelper(userAnswers: UserAnswers)(implicit messages: Messages) exten
           args = args: _*
         )
     }
-
-  def getAnswersAndBuildSectionRows(section: Section[JsArray])(f: Index => Option[SummaryListRow]): Seq[SummaryListRow] =
-    userAnswers
-      .get(section)
-      .mapWithIndex {
-        case (_, index) => f(index)
-      }
-      .flatten
 }

--- a/app/utils/answersHelpers/ConsignmentAnswersHelper.scala
+++ b/app/utils/answersHelpers/ConsignmentAnswersHelper.scala
@@ -190,22 +190,13 @@ class ConsignmentAnswersHelper(userAnswers: UserAnswers)(implicit messages: Mess
             helper.transportMeansNumber,
             helper.transportRegisteredCountry
           ).flatten
-          (rows, index)
+          AccordionSection(
+            sectionTitle = Some(messages("unloadingFindings.subsections.transportMeans", index.display)),
+            rows = rows,
+            id = Some(s"departureTransportMeans$index")
+          )
       } match {
-      case Nil =>
-        StaticSection(
-          sectionTitle = Some(messages("unloadingFindings.subsections.transportMeans.parent.header")),
-          viewLinks = Seq(departureTransportMeansAddRemoveLink)
-        )
-      case sections =>
-        val children = sections.map {
-          case (rows, index) =>
-            AccordionSection(
-              sectionTitle = Some(messages("unloadingFindings.subsections.transportMeans", index.display)),
-              rows = rows,
-              id = Some(s"departureTransportMeans$index")
-            )
-        }
+      case children =>
         AccordionSection(
           sectionTitle = Some(messages("unloadingFindings.subsections.transportMeans.parent.header")),
           children = children,
@@ -217,36 +208,25 @@ class ConsignmentAnswersHelper(userAnswers: UserAnswers)(implicit messages: Mess
   def transportEquipmentSection: Section =
     userAnswers.get(TransportEquipmentListSection).mapWithIndex {
       case (_, index) =>
-        val helper       = new TransportEquipmentAnswersHelper(userAnswers, index)
-        val container    = helper.containerIdentificationNumber
-        val sealsSection = helper.transportEquipmentSeals
-        val itemsSection = helper.transportEquipmentItems
-        (container, sealsSection, itemsSection, index)
-    } match {
-      case Nil =>
-        StaticSection(
-          sectionTitle = Some(messages("unloadingFindings.subsections.transportEquipment.parent.heading")),
-          viewLinks = Seq(transportEquipmentAddRemoveLink)
+        val helper = new TransportEquipmentAnswersHelper(userAnswers, index)
+        val rows   = Seq(helper.containerIdentificationNumber).flatten
+        val children = Seq(
+          helper.transportEquipmentSeals,
+          helper.transportEquipmentItems
+        ).flatten
+        AccordionSection(
+          sectionTitle = Some(messages("unloadingFindings.subsections.transportEquipment", index.display)),
+          viewLinks = Nil,
+          rows = rows,
+          children = children,
+          id = Some(s"transportEquipment$index")
         )
-      case sectionsRows =>
-        val transportEquipments = sectionsRows.map {
-          case (containerRow, sealsSection, itemsSection, index) =>
-            AccordionSection(
-              sectionTitle = Some(messages("unloadingFindings.subsections.transportEquipment", index.display)),
-              viewLinks = Nil,
-              rows = Seq(containerRow).flatten,
-              children = Seq(
-                sealsSection,
-                itemsSection
-              ).flatten,
-              id = Some(s"transportEquipment$index")
-            )
-        }
-
+    } match {
+      case children =>
         AccordionSection(
           sectionTitle = Some(messages("unloadingFindings.subsections.transportEquipment.parent.heading")),
           viewLinks = Seq(transportEquipmentAddRemoveLink),
-          children = transportEquipments,
+          children = children,
           id = Some("transportEquipments")
         )
     }
@@ -256,22 +236,13 @@ class ConsignmentAnswersHelper(userAnswers: UserAnswers)(implicit messages: Mess
       case (_, index) =>
         val helper = new AdditionalReferenceAnswersHelper(userAnswers, index)
         val rows   = Seq(helper.code, helper.referenceNumber).flatten
-        (rows, index)
-    } match {
-      case Nil =>
-        StaticSection(
-          sectionTitle = Some(messages("unloadingFindings.additional.reference.heading")),
-          viewLinks = Seq(additionalReferenceAddRemoveLink)
+        AccordionSection(
+          sectionTitle = Some(messages("unloadingFindings.additional.reference", index.display)),
+          rows = rows,
+          id = Some(s"additionalReference$index")
         )
-      case sectionsRows =>
-        val children = sectionsRows.map {
-          case (rows, index) =>
-            AccordionSection(
-              sectionTitle = Some(messages("unloadingFindings.additional.reference", index.display)),
-              rows = rows,
-              id = Some(s"additionalReference$index")
-            )
-        }
+    } match {
+      case children =>
         AccordionSection(
           sectionTitle = Some(messages("unloadingFindings.additional.reference.heading")),
           viewLinks = Seq(additionalReferenceAddRemoveLink),
@@ -281,23 +252,22 @@ class ConsignmentAnswersHelper(userAnswers: UserAnswers)(implicit messages: Mess
     }
 
   def additionalInformationSection: Option[Section] =
-    userAnswers.get(AdditionalInformationListSection).mapWithIndex {
-      case (_, index) =>
-        val helper = new AdditionalInformationAnswersHelper(userAnswers, index)
-        val rows   = Seq(helper.code, helper.description).flatten
-        (rows, index)
-    } match {
+    userAnswers
+      .get(AdditionalInformationListSection)
+      .mapWithIndex {
+        case (_, index) =>
+          val helper = new AdditionalInformationAnswersHelper(userAnswers, index)
+          val rows   = Seq(helper.code, helper.description).flatten
+          AccordionSection(
+            sectionTitle = Some(messages("unloadingFindings.additionalInformation.label", index.display)),
+            rows = rows,
+            id = Some(s"additionalInformation$index")
+          )
+      }
+      .toList match {
       case Nil =>
         None
-      case sectionsRows =>
-        val children = sectionsRows.map {
-          case (rows, index) =>
-            AccordionSection(
-              sectionTitle = Some(messages("unloadingFindings.additionalInformation.label", index.display)),
-              rows = rows,
-              id = Some(s"additionalInformation$index")
-            )
-        }
+      case children =>
         Some(
           AccordionSection(
             sectionTitle = Some(messages("unloadingFindings.additionalInformation.heading")),
@@ -347,12 +317,13 @@ class ConsignmentAnswersHelper(userAnswers: UserAnswers)(implicit messages: Mess
           )
       }
       .toList match {
-      case Nil => None
-      case sections =>
+      case Nil =>
+        None
+      case children =>
         Some(
           AccordionSection(
             sectionTitle = Some(messages("unloadingFindings.subsections.incidents.parent.header")),
-            children = sections,
+            children = children,
             id = Some("incidents")
           )
         )
@@ -369,26 +340,18 @@ class ConsignmentAnswersHelper(userAnswers: UserAnswers)(implicit messages: Mess
           helper.referenceNumber(readOnly),
           helper.additionalInformation(readOnly)
         ).flatten
-        (rows, index)
-    } match {
-      case Nil =>
-        StaticSection(
-          sectionTitle = Some(messages("unloadingFindings.document.heading.parent.heading")),
-          viewLinks = Seq(documentAddRemoveLink)
+
+        AccordionSection(
+          sectionTitle = Some(messages("unloadingFindings.document.heading", index.display)),
+          rows = rows,
+          id = Some(s"document$index")
         )
-      case documentSectionRows =>
-        val documents = documentSectionRows.map {
-          case (rows, index) =>
-            AccordionSection(
-              sectionTitle = Some(messages("unloadingFindings.document.heading", index.display)),
-              rows = rows,
-              id = Some(s"document$index")
-            )
-        }
+    } match {
+      case children =>
         AccordionSection(
           sectionTitle = Some(messages("unloadingFindings.document.heading.parent.heading")),
           viewLinks = Seq(documentAddRemoveLink),
-          children = documents,
+          children = children,
           id = Some("documents")
         )
     }
@@ -419,12 +382,13 @@ class ConsignmentAnswersHelper(userAnswers: UserAnswers)(implicit messages: Mess
           )
       }
       .toList match {
-      case Nil => None
-      case sections =>
+      case Nil =>
+        None
+      case children =>
         Some(
           AccordionSection(
             sectionTitle = Some(messages("unloadingFindings.subsections.houseConsignment.parent.heading")),
-            children = sections,
+            children = children,
             id = Some("houseConsignments")
           )
         )

--- a/app/utils/answersHelpers/ConsignmentAnswersHelper.scala
+++ b/app/utils/answersHelpers/ConsignmentAnswersHelper.scala
@@ -400,14 +400,10 @@ class ConsignmentAnswersHelper(userAnswers: UserAnswers)(implicit messages: Mess
       .mapWithIndex {
         case (_, index) =>
           val helper = new HouseConsignmentAnswersHelper(userAnswers, index)
-          val rows = Seq(
-            helper.consignorName,
-            helper.consignorIdentification
-          ).flatten
 
           AccordionSection(
             sectionTitle = messages("unloadingFindings.subsections.houseConsignment", index.display),
-            rows = rows,
+            rows = Nil,
             viewLinks = Seq(
               Link(
                 id = s"view-house-consignment-${index.display}",
@@ -416,7 +412,10 @@ class ConsignmentAnswersHelper(userAnswers: UserAnswers)(implicit messages: Mess
               )
             ),
             id = s"houseConsignment$index",
-            children = Seq(helper.houseConsignmentConsigneeSection)
+            children = Seq(
+              helper.houseConsignmentConsignorSection,
+              helper.houseConsignmentConsigneeSection
+            )
           )
       }
       .toList match {

--- a/app/utils/answersHelpers/ConsignmentAnswersHelper.scala
+++ b/app/utils/answersHelpers/ConsignmentAnswersHelper.scala
@@ -263,8 +263,7 @@ class ConsignmentAnswersHelper(userAnswers: UserAnswers)(implicit messages: Mess
             rows = rows,
             id = Some(s"additionalInformation$index")
           )
-      }
-      .toList match {
+      } match {
       case Nil =>
         None
       case children =>
@@ -315,8 +314,7 @@ class ConsignmentAnswersHelper(userAnswers: UserAnswers)(implicit messages: Mess
             children = Seq(endorsementSection) ++ helper.incidentTransportEquipments ++ Seq(transhipment),
             id = Some(s"incident$index")
           )
-      }
-      .toList match {
+      } match {
       case Nil =>
         None
       case children =>
@@ -380,8 +378,7 @@ class ConsignmentAnswersHelper(userAnswers: UserAnswers)(implicit messages: Mess
               helper.houseConsignmentConsigneeSection
             )
           )
-      }
-      .toList match {
+      } match {
       case Nil =>
         None
       case children =>

--- a/app/utils/answersHelpers/ConsignmentAnswersHelper.scala
+++ b/app/utils/answersHelpers/ConsignmentAnswersHelper.scala
@@ -276,6 +276,7 @@ class ConsignmentAnswersHelper(userAnswers: UserAnswers)(implicit messages: Mess
         )
     }
 
+  // scalastyle:off method.length
   def incidentSection: Option[Section] =
     userAnswers
       .get(IncidentsSection)
@@ -311,7 +312,11 @@ class ConsignmentAnswersHelper(userAnswers: UserAnswers)(implicit messages: Mess
           AccordionSection(
             sectionTitle = Some(messages("unloadingFindings.subsections.incidents", index.display)),
             rows = rows,
-            children = Seq(endorsementSection) ++ helper.incidentTransportEquipments ++ Seq(transhipment),
+            children = Seq(
+              Some(endorsementSection),
+              helper.incidentTransportEquipments,
+              Some(transhipment)
+            ).flatten,
             id = Some(s"incident$index")
           )
       } match {
@@ -326,6 +331,7 @@ class ConsignmentAnswersHelper(userAnswers: UserAnswers)(implicit messages: Mess
           )
         )
     }
+  // scalastyle:on method.length
 
   def documentSection: Section =
     userAnswers.get(DocumentsSection).mapWithIndex {

--- a/app/utils/answersHelpers/SummaryListRowHelper.scala
+++ b/app/utils/answersHelpers/SummaryListRowHelper.scala
@@ -166,33 +166,6 @@ class SummaryListRowHelper(implicit messages: Messages) {
       }
     )
 
-  def buildRowFromPath(
-    prefix: String,
-    answer: Content,
-    id: Option[String],
-    call: Option[Call],
-    args: Any*
-  ): SummaryListRow =
-    SummaryListRow(
-      key = messages(s"$prefix", args: _*).toKey,
-      value = Value(answer),
-      actions = call.map {
-        x =>
-          Actions(items =
-            List(
-              ActionItem(
-                content = messages("site.edit").toText,
-                href = x.url,
-                visuallyHiddenText = Some(messages(s"$prefix.change.hidden", args: _*)),
-                attributes = id.fold[Map[String, String]](Map.empty)(
-                  id => Map("id" -> id)
-                )
-              )
-            )
-          )
-      }
-    )
-
   def buildRemovableRow(
     prefix: String,
     answer: Content,

--- a/app/utils/answersHelpers/consignment/HouseConsignmentAnswersHelper.scala
+++ b/app/utils/answersHelpers/consignment/HouseConsignmentAnswersHelper.scala
@@ -134,16 +134,16 @@ class HouseConsignmentAnswersHelper(
           Seq(helper.netWeightRow),
           helper.cusCodeRow,
           Seq(helper.commodityCodeRow),
-          Seq(helper.nomenclatureCodeRow),
-          helper.dangerousGoodsRows
+          Seq(helper.nomenclatureCodeRow)
         ).flatten
 
         val children = Seq(
-          Seq(helper.itemLevelConsigneeSection),
-          Seq(helper.documentSection),
-          Seq(helper.additionalReferencesSection),
+          helper.dangerousGoodsSection,
+          Some(helper.itemLevelConsigneeSection),
+          Some(helper.documentSection),
+          Some(helper.additionalReferencesSection),
           helper.additionalInformationSection,
-          Seq(helper.packageSection)
+          Some(helper.packageSection)
         ).flatten
 
         AccordionSection(

--- a/app/utils/answersHelpers/consignment/HouseConsignmentAnswersHelper.scala
+++ b/app/utils/answersHelpers/consignment/HouseConsignmentAnswersHelper.scala
@@ -68,9 +68,10 @@ class HouseConsignmentAnswersHelper(
 
   def houseConsignmentConsignorSection: Section =
     StaticSection(
+      sectionTitle = messages("unloadingFindings.consignor.heading"),
       rows = Seq(
-        consignorName,
-        consignorIdentification
+        consignorIdentification,
+        consignorName
       ).flatten
     )
 
@@ -97,18 +98,35 @@ class HouseConsignmentAnswersHelper(
     prefix = "unloadingFindings.rowHeadings.houseConsignment.consigneeAddress"
   )
 
-  def departureTransportMeansSections: Seq[Section] =
+  def departureTransportMeansSection: Section =
     userAnswers.get(DepartureTransportMeansListSection(houseConsignmentIndex)).mapWithIndex {
       case (_, index) =>
         val helper = new DepartureTransportMeansAnswersHelper(userAnswers, houseConsignmentIndex, index)
+        val rows = Seq(
+          helper.transportMeansID,
+          helper.transportMeansIDNumber,
+          helper.buildVehicleNationalityRow
+        ).flatten
+        (rows, index)
+    } match {
+      case Nil =>
+        StaticSection(
+          sectionTitle = Some(messages("unloadingFindings.subsections.transportMeans.parent.header")),
+          id = Some("departureTransportMeans")
+        )
+      case dtmSectionRows =>
+        val dtms = dtmSectionRows.map {
+          case (rows, index) =>
+            AccordionSection(
+              sectionTitle = Some(messages("unloadingFindings.subsections.transportMeans", index.display)),
+              rows = rows,
+              id = Some(s"departureTransportMeans$index")
+            )
+        }
         AccordionSection(
-          sectionTitle = Some(messages("unloadingFindings.subsections.transportMeans", index.display)),
-          rows = Seq(
-            helper.transportMeansID,
-            helper.transportMeansIDNumber,
-            helper.buildVehicleNationalityRow
-          ).flatten,
-          id = Some(s"departureTransportMeans$index")
+          sectionTitle = Some(messages("unloadingFindings.subsections.transportMeans.parent.header")),
+          children = dtms,
+          id = Some("departureTransportMeans")
         )
     }
 

--- a/app/utils/answersHelpers/consignment/HouseConsignmentAnswersHelper.scala
+++ b/app/utils/answersHelpers/consignment/HouseConsignmentAnswersHelper.scala
@@ -107,25 +107,16 @@ class HouseConsignmentAnswersHelper(
           helper.transportMeansIDNumber,
           helper.buildVehicleNationalityRow
         ).flatten
-        (rows, index)
-    } match {
-      case Nil =>
-        StaticSection(
-          sectionTitle = Some(messages("unloadingFindings.subsections.transportMeans.parent.header")),
-          id = Some("departureTransportMeans")
+        AccordionSection(
+          sectionTitle = Some(messages("unloadingFindings.subsections.transportMeans", index.display)),
+          rows = rows,
+          id = Some(s"departureTransportMeans$index")
         )
-      case dtmSectionRows =>
-        val dtms = dtmSectionRows.map {
-          case (rows, index) =>
-            AccordionSection(
-              sectionTitle = Some(messages("unloadingFindings.subsections.transportMeans", index.display)),
-              rows = rows,
-              id = Some(s"departureTransportMeans$index")
-            )
-        }
+    } match {
+      case children =>
         AccordionSection(
           sectionTitle = Some(messages("unloadingFindings.subsections.transportMeans.parent.header")),
-          children = dtms,
+          children = children,
           id = Some("departureTransportMeans")
         )
     }
@@ -155,27 +146,18 @@ class HouseConsignmentAnswersHelper(
           Seq(helper.packageSection)
         ).flatten
 
-        (rows, children, index)
-    } match {
-      case Nil =>
-        StaticSection(
-          sectionTitle = Some(messages("unloadingFindings.subsections.item.parent.heading")),
-          viewLinks = Seq(itemsAddRemoveLink)
+        AccordionSection(
+          sectionTitle = Some(messages("unloadingFindings.subsections.item", index.display)),
+          rows = rows,
+          children = children,
+          id = Some(s"item-$index")
         )
-      case items =>
-        val itemSections = items.map {
-          case (rows, children, index) =>
-            AccordionSection(
-              sectionTitle = Some(messages("unloadingFindings.subsections.item", index.display)),
-              rows = rows,
-              children = children,
-              id = Some(s"item-$index")
-            )
-        }
+    } match {
+      case children =>
         AccordionSection(
           sectionTitle = Some(messages("unloadingFindings.subsections.item.parent.heading")),
           viewLinks = Seq(itemsAddRemoveLink),
-          children = itemSections,
+          children = children,
           id = Some("items")
         )
     }

--- a/app/utils/answersHelpers/consignment/TransportEquipmentAnswersHelper.scala
+++ b/app/utils/answersHelpers/consignment/TransportEquipmentAnswersHelper.scala
@@ -49,8 +49,7 @@ class TransportEquipmentAnswersHelper(
         case (_, index) =>
           val helper = new SealAnswersHelper(userAnswers, equipmentIndex, index)
           Seq(helper.transportEquipmentSeal).flatten
-      }
-      .toList match {
+      } match {
       case Nil =>
         None
       case rows =>
@@ -71,8 +70,7 @@ class TransportEquipmentAnswersHelper(
         case (_, index) =>
           val helper = new ItemAnswersHelper(userAnswers, equipmentIndex, index)
           Seq(helper.transportEquipmentItem).flatten
-      }
-      .toList match {
+      } match {
       case Nil =>
         None
       case rows =>

--- a/app/utils/answersHelpers/consignment/TransportEquipmentAnswersHelper.scala
+++ b/app/utils/answersHelpers/consignment/TransportEquipmentAnswersHelper.scala
@@ -51,7 +51,8 @@ class TransportEquipmentAnswersHelper(
           Seq(helper.transportEquipmentSeal).flatten
       }
       .toList match {
-      case Nil => None
+      case Nil =>
+        None
       case rows =>
         Some(
           AccordionSection(
@@ -72,7 +73,8 @@ class TransportEquipmentAnswersHelper(
           Seq(helper.transportEquipmentItem).flatten
       }
       .toList match {
-      case Nil => None
+      case Nil =>
+        None
       case rows =>
         Some(
           AccordionSection(

--- a/app/utils/answersHelpers/consignment/houseConsignment/ConsignmentItemAnswersHelper.scala
+++ b/app/utils/answersHelpers/consignment/houseConsignment/ConsignmentItemAnswersHelper.scala
@@ -127,8 +127,7 @@ class ConsignmentItemAnswersHelper(
             rows = rows,
             id = Some(s"item-$itemIndex-additional-information-$index")
           )
-      }
-      .toList match {
+      } match {
       case Nil =>
         None
       case children =>
@@ -170,12 +169,22 @@ class ConsignmentItemAnswersHelper(
         )
     }
 
-  // TODO - should be in a parent accordion
-  def dangerousGoodsRows: Seq[SummaryListRow] =
-    getAnswersAndBuildSectionRows(DangerousGoodsListSection(houseConsignmentIndex, itemIndex)) {
-      index =>
+  def dangerousGoodsSection: Option[Section] =
+    userAnswers.get(DangerousGoodsListSection(houseConsignmentIndex, itemIndex)).mapWithIndex {
+      case (_, index) =>
         val helper = new DangerousGoodsAnswerHelper(userAnswers, houseConsignmentIndex, itemIndex, index)
         helper.dangerousGoodsRow
+    } match {
+      case Nil =>
+        None
+      case rows =>
+        Some(
+          AccordionSection(
+            sectionTitle = Some(messages("unloadingFindings.dangerousGoods.unNumbers")),
+            rows = rows.flatten,
+            id = Some(s"item-$itemIndex-dangerous-goods")
+          )
+        )
     }
 
   def packageSection: Section =

--- a/app/utils/answersHelpers/consignment/houseConsignment/ConsignmentItemAnswersHelper.scala
+++ b/app/utils/answersHelpers/consignment/houseConsignment/ConsignmentItemAnswersHelper.scala
@@ -91,27 +91,19 @@ class ConsignmentItemAnswersHelper(
   )
 
   def additionalReferencesSection: Section =
-    userAnswers.get(AdditionalReferencesSection(houseConsignmentIndex, itemIndex)).mapWithIndex {
-      case (_, index) =>
-        val helper = new AdditionalReferencesAnswerHelper(userAnswers, houseConsignmentIndex, itemIndex, index)
-        val rows   = Seq(helper.code, helper.referenceNumber).flatten
-        (rows, index)
-    } match {
-      case Nil =>
-        StaticSection(
-          sectionTitle = Some(messages("unloadingFindings.additional.reference.heading")),
-          viewLinks = Seq(additionalReferenceAddRemoveLink),
-          id = Some(s"item-$itemIndex-additional-references")
-        )
-      case sectionsRows =>
-        val children = sectionsRows.map {
-          case (rows, index) =>
-            AccordionSection(
-              sectionTitle = Some(messages("unloadingFindings.houseConsignment.item.additionalReference", index.display)),
-              rows = rows,
-              id = Some(s"item-$itemIndex-additional-reference-$index")
-            )
-        }
+    userAnswers
+      .get(AdditionalReferencesSection(houseConsignmentIndex, itemIndex))
+      .mapWithIndex {
+        case (_, index) =>
+          val helper = new AdditionalReferencesAnswerHelper(userAnswers, houseConsignmentIndex, itemIndex, index)
+          val rows   = Seq(helper.code, helper.referenceNumber).flatten
+          AccordionSection(
+            sectionTitle = Some(messages("unloadingFindings.houseConsignment.item.additionalReference", index.display)),
+            rows = rows,
+            id = Some(s"item-$itemIndex-additional-reference-$index")
+          )
+      } match {
+      case children =>
         AccordionSection(
           sectionTitle = Some(messages("unloadingFindings.additional.reference.heading")),
           viewLinks = Seq(additionalReferenceAddRemoveLink),
@@ -121,26 +113,25 @@ class ConsignmentItemAnswersHelper(
     }
 
   def additionalInformationSection: Option[Section] =
-    userAnswers.get(AdditionalInformationsSection(houseConsignmentIndex, itemIndex)).mapWithIndex {
-      case (_, index) =>
-        val helper = new AdditionalInformationsAnswerHelper(userAnswers, houseConsignmentIndex, itemIndex, index)
-        val rows = Seq(
-          helper.additionalInformationCodeRow,
-          helper.additionalInformationTextRow
-        ).flatten
-        (rows, index)
-    } match {
+    userAnswers
+      .get(AdditionalInformationsSection(houseConsignmentIndex, itemIndex))
+      .mapWithIndex {
+        case (_, index) =>
+          val helper = new AdditionalInformationsAnswerHelper(userAnswers, houseConsignmentIndex, itemIndex, index)
+          val rows = Seq(
+            helper.additionalInformationCodeRow,
+            helper.additionalInformationTextRow
+          ).flatten
+          AccordionSection(
+            sectionTitle = Some(messages("unloadingFindings.additionalInformation.label", index.display)),
+            rows = rows,
+            id = Some(s"item-$itemIndex-additional-information-$index")
+          )
+      }
+      .toList match {
       case Nil =>
         None
-      case sectionsRows =>
-        val children = sectionsRows.map {
-          case (rows, index) =>
-            AccordionSection(
-              sectionTitle = Some(messages("unloadingFindings.additionalInformation.label", index.display)),
-              rows = rows,
-              id = Some(s"item-$itemIndex-additional-information-$index")
-            )
-        }
+      case children =>
         Some(
           AccordionSection(
             sectionTitle = Some(messages("unloadingFindings.additionalInformation.heading")),
@@ -151,41 +142,35 @@ class ConsignmentItemAnswersHelper(
     }
 
   def documentSection: Section =
-    userAnswers.get(DocumentsSection(houseConsignmentIndex, itemIndex)).mapWithIndex {
-      case (_, index) =>
-        val helper   = new DocumentAnswersHelper(userAnswers, houseConsignmentIndex, itemIndex, index)
-        val readOnly = userAnswers.get(TypePage(houseConsignmentIndex, itemIndex, index)).map(_.`type`).contains(Previous)
+    userAnswers
+      .get(DocumentsSection(houseConsignmentIndex, itemIndex))
+      .mapWithIndex {
+        case (_, index) =>
+          val helper   = new DocumentAnswersHelper(userAnswers, houseConsignmentIndex, itemIndex, index)
+          val readOnly = userAnswers.get(TypePage(houseConsignmentIndex, itemIndex, index)).map(_.`type`).contains(Previous)
 
-        val rows = Seq(
-          helper.documentType(readOnly),
-          helper.referenceNumber(readOnly),
-          helper.additionalInformation(readOnly)
-        ).flatten
-        (rows, index)
-    } match {
-      case Nil =>
-        StaticSection(
-          sectionTitle = Some(messages("unloadingFindings.document.heading.parent.heading")),
-          viewLinks = Seq(documentAddRemoveLink),
-          id = Some(s"item-$itemIndex-documents")
-        )
-      case documentSectionRows =>
-        val documents = documentSectionRows.map {
-          case (rows, index) =>
-            AccordionSection(
-              sectionTitle = Some(messages("unloadingFindings.document.heading", index.display)),
-              rows = rows,
-              id = Some(s"item-$itemIndex-document-$index")
-            )
-        }
+          val rows = Seq(
+            helper.documentType(readOnly),
+            helper.referenceNumber(readOnly),
+            helper.additionalInformation(readOnly)
+          ).flatten
+
+          AccordionSection(
+            sectionTitle = Some(messages("unloadingFindings.document.heading", index.display)),
+            rows = rows,
+            id = Some(s"item-$itemIndex-document-$index")
+          )
+      } match {
+      case children =>
         AccordionSection(
           sectionTitle = Some(messages("unloadingFindings.document.heading.parent.heading")),
           viewLinks = Seq(documentAddRemoveLink),
-          children = documents,
+          children = children,
           id = Some(s"item-$itemIndex-documents")
         )
     }
 
+  // TODO - should be in a parent accordion
   def dangerousGoodsRows: Seq[SummaryListRow] =
     getAnswersAndBuildSectionRows(DangerousGoodsListSection(houseConsignmentIndex, itemIndex)) {
       index =>
@@ -194,32 +179,25 @@ class ConsignmentItemAnswersHelper(
     }
 
   def packageSection: Section =
-    userAnswers.get(PackagingListSection(houseConsignmentIndex, itemIndex)).mapWithIndex {
-      case (_, index) =>
-        val helper = new PackagingAnswersHelper(userAnswers, houseConsignmentIndex, itemIndex, index)
+    userAnswers
+      .get(PackagingListSection(houseConsignmentIndex, itemIndex))
+      .mapWithIndex {
+        case (_, index) =>
+          val helper = new PackagingAnswersHelper(userAnswers, houseConsignmentIndex, itemIndex, index)
 
-        val rows = Seq(helper.packageTypeRow, helper.packageCountRow, helper.packageMarksRow).flatten
-        (rows, index)
-    } match {
-      case Nil =>
-        StaticSection(
-          sectionTitle = Some(messages("unloadingFindings.subsections.packages.parent.heading")),
-          viewLinks = Seq(packagingAddRemoveLink),
-          id = Some(s"item-$itemIndex-packages")
-        )
-      case packageSectionRows =>
-        val packages = packageSectionRows.map {
-          case (rows, index) =>
-            AccordionSection(
-              sectionTitle = Some(messages("unloadingFindings.subsections.packages", index.display)),
-              rows = rows,
-              id = Some(s"item-$itemIndex-package-$index")
-            )
-        }
+          val rows = Seq(helper.packageTypeRow, helper.packageCountRow, helper.packageMarksRow).flatten
+
+          AccordionSection(
+            sectionTitle = Some(messages("unloadingFindings.subsections.packages", index.display)),
+            rows = rows,
+            id = Some(s"item-$itemIndex-package-$index")
+          )
+      } match {
+      case children =>
         AccordionSection(
           sectionTitle = Some(messages("unloadingFindings.subsections.packages.parent.heading")),
           viewLinks = Seq(packagingAddRemoveLink),
-          children = packages,
+          children = children,
           id = Some(s"item-$itemIndex-packages")
         )
     }

--- a/app/utils/answersHelpers/consignment/incident/IncidentAnswersHelper.scala
+++ b/app/utils/answersHelpers/consignment/incident/IncidentAnswersHelper.scala
@@ -160,7 +160,7 @@ class IncidentAnswersHelper(userAnswers: UserAnswers, incidentIndex: Index)(impl
     prefix = "unloadingFindings.rowHeadings.containerIndicator"
   )
 
-  def incidentTransportEquipments: Seq[Section] =
+  def incidentTransportEquipments: Option[Section] =
     userAnswers.ie043Data.Consignment
       .flatMap(_.Incident.lift(incidentIndex.position))
       .map(_.TransportEquipment)
@@ -168,9 +168,9 @@ class IncidentAnswersHelper(userAnswers: UserAnswers, incidentIndex: Index)(impl
       .flatten
       .zipWithIndex
       .map {
-        case (transportEquipmentType0, index) =>
+        case (transportEquipment, index) =>
           val equipmentIndex = Index(index)
-          val helper         = new IncidentTransportEquipmentAnswersHelper(userAnswers, transportEquipmentType0)
+          val helper         = new IncidentTransportEquipmentAnswersHelper(userAnswers, transportEquipment)
 
           val rows = Seq(helper.containerIdentificationNumber).flatten
 
@@ -185,7 +185,17 @@ class IncidentAnswersHelper(userAnswers: UserAnswers, incidentIndex: Index)(impl
             children = children,
             id = Some(s"incident-$incidentIndex-transport-equipment-$index")
           )
-      }
+      } match {
+      case Nil =>
+        None
+      case children =>
+        Some(
+          AccordionSection(
+            sectionTitle = Some(messages("unloadingFindings.incident.transportEquipment.parent.heading")),
+            children = children
+          )
+        )
+    }
 
   def incidentReplacementMeansOfTransport: Seq[SummaryListRow] = {
     val maybeTranshipmentType0: Option[TranshipmentType02] = userAnswers.ie043Data.Consignment

--- a/app/utils/answersHelpers/consignment/incident/IncidentAnswersHelper.scala
+++ b/app/utils/answersHelpers/consignment/incident/IncidentAnswersHelper.scala
@@ -172,11 +172,17 @@ class IncidentAnswersHelper(userAnswers: UserAnswers, incidentIndex: Index)(impl
           val equipmentIndex = Index(index)
           val helper         = new IncidentTransportEquipmentAnswersHelper(userAnswers, transportEquipmentType0)
 
-          val rows = Seq(helper.containerIdentificationNumber, helper.transportEquipmentSeals, helper.itemNumber).flatten
+          val rows = Seq(helper.containerIdentificationNumber).flatten
+
+          val children = Seq(
+            helper.transportEquipmentSeals,
+            helper.itemNumbers
+          ).flatten
 
           AccordionSection(
             sectionTitle = Some(messages("unloadingFindings.incident.transportEquipment.heading", equipmentIndex.display)),
             rows = rows,
+            children = children,
             id = Some(s"incident-$incidentIndex-transport-equipment-$index")
           )
       }

--- a/app/utils/answersHelpers/consignment/incident/IncidentTransportEquipmentAnswersHelper.scala
+++ b/app/utils/answersHelpers/consignment/incident/IncidentTransportEquipmentAnswersHelper.scala
@@ -21,6 +21,8 @@ import models.{Index, UserAnswers}
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import utils.answersHelpers.AnswersHelper
+import viewModels.sections.Section
+import viewModels.sections.Section.AccordionSection
 
 class IncidentTransportEquipmentAnswersHelper(
   userAnswers: UserAnswers,
@@ -34,7 +36,7 @@ class IncidentTransportEquipmentAnswersHelper(
     prefix = "unloadingFindings.rowHeadings.containerIdentificationNumber"
   )
 
-  def transportEquipmentSeals: Seq[SummaryListRow] =
+  def transportEquipmentSeals: Option[Section] =
     transportEquipmentType7.Seal.zipWithIndex.flatMap {
       case (sealType0, i) =>
         val sealIndex = Index(i)
@@ -44,10 +46,19 @@ class IncidentTransportEquipmentAnswersHelper(
           prefix = "unloadingFindings.rowHeadings.sealIdentifier",
           args = sealIndex.display
         )
-
+    } match {
+      case Nil =>
+        None
+      case rows =>
+        Some(
+          AccordionSection(
+            sectionTitle = Some(messages("unloadingFindings.incident.transportEquipment.seals.heading")),
+            rows = rows
+          )
+        )
     }
 
-  def itemNumber: Seq[SummaryListRow] =
+  def itemNumbers: Option[Section] =
     transportEquipmentType7.GoodsReference.zipWithIndex.flatMap {
       case (type0, i) =>
         val itemIndex = Index(i)
@@ -57,7 +68,15 @@ class IncidentTransportEquipmentAnswersHelper(
           prefix = "unloadingFindings.rowHeadings.incident.item",
           args = itemIndex.display
         )
-
+    } match {
+      case Nil =>
+        None
+      case rows =>
+        Some(
+          AccordionSection(
+            sectionTitle = Some(messages("unloadingFindings.incident.transportEquipment.goodsItemNumbers.heading")),
+            rows = rows
+          )
+        )
     }
-
 }

--- a/app/viewModels/HouseConsignmentViewModel.scala
+++ b/app/viewModels/HouseConsignmentViewModel.scala
@@ -37,11 +37,12 @@ object HouseConsignmentViewModel {
     def apply(userAnswers: UserAnswers, houseConsignmentIndex: Index)(implicit messages: Messages): HouseConsignmentViewModel = {
       val helper = new HouseConsignmentAnswersHelper(userAnswers, houseConsignmentIndex)
 
-      val sections: Seq[Section] =
-        helper.departureTransportMeansSections ++
-          Seq(helper.itemSection) ++
-          Seq(helper.houseConsignmentConsignorSection) ++
-          Seq(helper.houseConsignmentConsigneeSection)
+      val sections: Seq[Section] = Seq(
+        helper.departureTransportMeansSection,
+        helper.itemSection,
+        helper.houseConsignmentConsignorSection,
+        helper.houseConsignmentConsigneeSection
+      )
 
       HouseConsignmentViewModel(sections)
     }

--- a/app/viewModels/sections/Section.scala
+++ b/app/viewModels/sections/Section.scala
@@ -25,6 +25,15 @@ sealed trait Section {
   val children: Seq[Section]
   val viewLinks: Seq[Link]
   val id: Option[String]
+
+  def margin: String = {
+    val indent = if (sectionTitle.isDefined) 1 else 0
+    s"govuk-!-margin-left-${2 * indent}"
+  }
+
+  def isEmpty: Boolean
+
+  def nonEmpty: Boolean = !isEmpty
 }
 
 object Section {
@@ -35,7 +44,10 @@ object Section {
     children: Seq[Section] = Nil,
     viewLinks: Seq[Link] = Nil,
     id: Option[String] = None
-  ) extends Section
+  ) extends Section {
+
+    override def isEmpty: Boolean = false
+  }
 
   object AccordionSection {
 
@@ -55,6 +67,8 @@ object Section {
     viewLinks: Seq[Link] = Nil,
     id: Option[String] = None
   ) extends Section {
+
+    override def isEmpty: Boolean = rows.isEmpty
 
     override val children: Seq[Section] = Seq.empty
   }

--- a/app/views/components/AnswerSection.scala.html
+++ b/app/views/components/AnswerSection.scala.html
@@ -28,26 +28,28 @@
 @if(section.nonEmpty) {
     @section match {
         case x: StaticSection => {
-            @section.sectionTitle.map { title =>
-                <h2 class="govuk-heading-m">@title</h2>
-            }
+            <div class="govuk-!-margin-bottom-9">
+                @section.sectionTitle.map { title =>
+                    <h2 class="govuk-heading-m">@title</h2>
+                }
 
-            <div class="@section.margin">
-                @if(section.rows.nonEmpty) {
-                    @govukSummaryList(
-                        SummaryList(
-                            rows = section.rows
+                <div class="@section.margin">
+                    @if(section.rows.nonEmpty) {
+                        @govukSummaryList(
+                            SummaryList(
+                                rows = section.rows
+                            )
                         )
-                    )
-                }
+                    }
 
-                @section.viewLinks.map { link =>
-                    <p class="govuk-body">
-                        <a class="govuk-link" href=@link.href id="@link.id">
-                            @messages(link.text) <span class="govuk-visually-hidden">@link.visuallyHidden</span>
-                        </a>
-                    </p>
-                }
+                    @section.viewLinks.map { link =>
+                        <p class="govuk-body">
+                            <a class="govuk-link" href=@link.href id="@link.id">
+                                @messages(link.text) <span class="govuk-visually-hidden">@link.visuallyHidden</span>
+                            </a>
+                        </p>
+                    }
+                </div>
             </div>
         }
         case x: AccordionSection => {

--- a/app/views/components/AnswerSection.scala.html
+++ b/app/views/components/AnswerSection.scala.html
@@ -23,39 +23,42 @@
     govukDetails: GovukDetails
 )
 
-@(section: Section, nestingLevel: Int = 0)(implicit messages: Messages)
+@(section: Section)(implicit messages: Messages)
 
-@section match {
-    case x: StaticSection => {
-        @section.sectionTitle.map { title =>
-            <h2 class="govuk-heading-m">@title</h2>
+@if(section.nonEmpty) {
+    @section match {
+        case x: StaticSection => {
+            @section.sectionTitle.map { title =>
+                <h2 class="govuk-heading-m">@title</h2>
+            }
+
+            <div class="@section.margin">
+                @if(section.rows.nonEmpty) {
+                    @govukSummaryList(
+                        SummaryList(
+                            rows = section.rows
+                        )
+                    )
+                }
+
+                @section.viewLinks.map { link =>
+                    <p class="govuk-body">
+                        <a class="govuk-link" href=@link.href id="@link.id">
+                            @messages(link.text) <span class="govuk-visually-hidden">@link.visuallyHidden</span>
+                        </a>
+                    </p>
+                }
+            </div>
         }
-
-        @if(section.rows.nonEmpty) {
-            @govukSummaryList(
-                SummaryList(
-                    rows = section.rows
+        case x: AccordionSection => {
+            @govukDetails(
+                Details(
+                    summary = HtmlContent(header),
+                    content = HtmlContent(content),
+                    id = section.id
                 )
             )
         }
-
-        @section.viewLinks.map { link =>
-            <p class="govuk-body">
-                <a class="govuk-link" href=@link.href id="@link.id">
-                    @messages(link.text) <span class="govuk-visually-hidden">@link.visuallyHidden</span>
-                </a>
-            </p>
-        }
-    }
-    case x: AccordionSection => {
-        @govukDetails(
-            Details(
-                summary = HtmlContent(header),
-                content = HtmlContent(content),
-                id = section.id,
-                classes = s"govuk-!-margin-left-${2 * nestingLevel}"
-            )
-        )
     }
 }
 
@@ -68,23 +71,25 @@
 }
 
 @content = {
-    @if(section.rows.nonEmpty) {
-        @govukSummaryList(
-            SummaryList(
-                rows = section.rows
+    <div class="@section.margin">
+        @if(section.rows.nonEmpty) {
+            @govukSummaryList(
+                SummaryList(
+                    rows = section.rows
+                )
             )
-        )
-    } else if(section.children.isEmpty) {
-        <p class="govuk-body">@messages("unloadingFindings.noInformationProvided")</p>
-    }
+        } else if(section.children.isEmpty) {
+            <p class="govuk-body">@messages("unloadingFindings.noInformationProvided")</p>
+        }
 
-    @section.children.map(this(_, nestingLevel + 1))
+        @section.children.map(this(_))
 
-    @section.viewLinks.map { link =>
-        <p class="govuk-body">
-            <a class="govuk-link" href=@link.href id="@link.id">
-                @messages(link.text) <span class="govuk-visually-hidden">@link.visuallyHidden</span>
-            </a>
-        </p>
-    }
+        @section.viewLinks.map { link =>
+            <p class="govuk-body">
+                <a class="govuk-link" href=@link.href id="@link.id">
+                    @messages(link.text) <span class="govuk-visually-hidden">@link.visuallyHidden</span>
+                </a>
+            </p>
+        }
+    </div>
 }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -426,6 +426,8 @@ unloadingFindings.rowHeadings.replacementMeansOfTransport.identificationNumber =
 unloadingFindings.rowHeadings.replacementMeansOfTransport.nationality = Registered country
 
 unloadingFindings.incident.transportEquipment.heading = Transport equipment {0}
+unloadingFindings.incident.transportEquipment.seals.heading = Seals
+unloadingFindings.incident.transportEquipment.goodsItemNumbers.heading = Goods item numbers
 
 declarationType = Declaration type
 securityType = Safety and security details

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -26,7 +26,6 @@ site.caption = MRN: {0}
 site.email.link = If you have any questions or issues, email us at {0}
 site.email.subject = NCTS Phase 5 - Help with testing
 
-unloadingFindings.sequenceNumber = Sequence number
 unloadingFindings.noInformationProvided = No information provided
 
 error.title.prefix = Error:
@@ -579,6 +578,7 @@ unloadingFindings.additional.information.heading = Additional information {0}
 unloadingFindings.additional.information.code = Type
 unloadingFindings.additional.information.description = Description
 
+unloadingFindings.dangerousGoods.unNumbers = UN numbers
 unloadingFindings.dangerousGoods.unNumber = UN number {0}
 unloadingFindings.dangerousGoods.unNumber.change.hidden = UN number {0} for item {1}
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -425,6 +425,7 @@ unloadingFindings.rowHeadings.replacementMeansOfTransport.typeOfIdentification =
 unloadingFindings.rowHeadings.replacementMeansOfTransport.identificationNumber = Identification number
 unloadingFindings.rowHeadings.replacementMeansOfTransport.nationality = Registered country
 
+unloadingFindings.incident.transportEquipment.parent.heading = Transport equipment
 unloadingFindings.incident.transportEquipment.heading = Transport equipment {0}
 unloadingFindings.incident.transportEquipment.seals.heading = Seals
 unloadingFindings.incident.transportEquipment.goodsItemNumbers.heading = Goods item numbers

--- a/test/controllers/transportEquipment/index/ApplyAnotherItemControllerSpec.scala
+++ b/test/controllers/transportEquipment/index/ApplyAnotherItemControllerSpec.scala
@@ -72,6 +72,24 @@ class ApplyAnotherItemControllerSpec extends SpecBase with AppWithDefaultMockFix
   "ApplyAnotherItem Controller" - {
 
     "must return OK and the correct view for a GET" - {
+      "when 0 goods references" in {
+        when(mockViewModelProvider.apply(any(), any(), any(), any(), any(), any())(any()))
+          .thenReturn(emptyViewModel)
+
+        setExistingUserAnswers(emptyUserAnswers)
+
+        val request = FakeRequest(GET, applyAnotherItemRoute)
+
+        val result = route(app, request).value
+
+        val view = injector.instanceOf[ApplyAnotherItemView]
+
+        status(result) mustEqual OK
+
+        contentAsString(result) mustEqual
+          view(form(emptyViewModel, equipmentIndex), mrn, arrivalId, emptyViewModel)(request, messages, frontendAppConfig).toString
+      }
+
       "when max limit not reached" in {
         when(mockViewModelProvider.apply(any(), any(), any(), any(), any(), any())(any()))
           .thenReturn(notMaxedOutViewModel)

--- a/test/utils/answersHelpers/ConsignmentAnswersHelperSpec.scala
+++ b/test/utils/answersHelpers/ConsignmentAnswersHelperSpec.scala
@@ -432,14 +432,15 @@ class ConsignmentAnswersHelperSpec extends AnswersHelperSpecBase {
 
             result.children.head mustBe a[AccordionSection]
             result.children.head.sectionTitle.value mustBe "House consignment 1"
-            result.children.head.rows.size mustBe 2
-            result.children.head.rows.head.value.value mustBe consignorName
-            result.children.head.rows(1).value.value mustBe consignorId
-            result.children.head.children must not be empty
+            result.children.head.rows.size mustBe 0
 
-            result.children.head.children.head.sectionTitle.get mustBe "Consignee"
-            result.children.head.children.head.rows.head.value.value mustBe consigneeId
-            result.children.head.children.head.rows(1).value.value mustBe consigneeName
+            result.children.head.children.head.sectionTitle.value mustBe "Consignor"
+            result.children.head.children.head.rows.head.value.value mustBe consignorId
+            result.children.head.children.head.rows(1).value.value mustBe consignorName
+
+            result.children.head.children(1).sectionTitle.value mustBe "Consignee"
+            result.children.head.children(1).rows.head.value.value mustBe consigneeId
+            result.children.head.children(1).rows(1).value.value mustBe consigneeName
 
             val link = result.children.head.viewLinks.head
             link.id mustBe "view-house-consignment-1"

--- a/test/utils/answersHelpers/consignment/HouseConsignmentAnswersHelperSpec.scala
+++ b/test/utils/answersHelpers/consignment/HouseConsignmentAnswersHelperSpec.scala
@@ -209,16 +209,21 @@ class HouseConsignmentAnswersHelperSpec extends AnswersHelperSpecBase {
               .setValue(DepartureTransportMeansCountryPage(hcIndex, dtmIndex), country)
 
             val helper = new HouseConsignmentAnswersHelper(answers, hcIndex)
-            val result = helper.departureTransportMeansSections
+            val result = helper.departureTransportMeansSection
 
-            result.head mustBe a[AccordionSection]
-            result.head.sectionTitle.value mustBe "Departure means of transport 1"
-            result.head.rows.size mustBe 3
-            result.head.id.value mustBe "departureTransportMeans1"
+            result mustBe a[AccordionSection]
+            result.sectionTitle.value mustBe "Departure means of transport"
+            result.children.size mustBe 1
 
-            result.head.rows.head.value.value mustBe `type`.description
-            result.head.rows(1).value.value mustBe number
-            result.head.rows(2).value.value mustBe country.description
+            val dtm1 = result.children.head
+            dtm1 mustBe a[AccordionSection]
+            dtm1.sectionTitle.value mustBe "Departure means of transport 1"
+            dtm1.id.value mustBe "departureTransportMeans1"
+            dtm1.rows.size mustBe 3
+
+            dtm1.rows.head.value.value mustBe `type`.description
+            dtm1.rows(1).value.value mustBe number
+            dtm1.rows(2).value.value mustBe country.description
         }
       }
     }

--- a/test/utils/answersHelpers/consignment/HouseConsignmentAnswersHelperSpec.scala
+++ b/test/utils/answersHelpers/consignment/HouseConsignmentAnswersHelperSpec.scala
@@ -29,6 +29,7 @@ import pages.houseConsignment.index.items.{
   CombinedNomenclatureCodePage,
   CommodityCodePage,
   CustomsUnionAndStatisticsCodePage,
+  DangerousGoodsPage,
   GrossWeightPage,
   ItemDescriptionPage,
   NetWeightPage,
@@ -230,112 +231,125 @@ class HouseConsignmentAnswersHelperSpec extends AnswersHelperSpecBase {
 
     "itemSections" - {
       "must generate accordion sections" in {
-        forAll(Gen.alphaNumStr, arbitrary[BigDecimal], arbitrary[Double], arbitrary[PackageType], arbitrary[BigInt], arbitrary[AdditionalReferenceType]) {
-          (description, grossWeight, netWeight, packageType, count, additionalReference) =>
-            val (cusCode, commodityCode, nomenclatureCode, additionalInformation) =
-              ("cusCode", "commodityCode", "nomenclatureCode", AdditionalInformationCode("code", "description"))
-            val answers = emptyUserAnswers
-              .setValue(ItemDescriptionPage(hcIndex, itemIndex), description)
-              .setValue(GrossWeightPage(hcIndex, itemIndex), grossWeight)
-              .setValue(NetWeightPage(hcIndex, itemIndex), netWeight)
-              .setValue(PackageTypePage(hcIndex, itemIndex, packageIndex), packageType)
-              .setValue(NumberOfPackagesPage(hcIndex, itemIndex, packageIndex), count)
-              .setValue(PackageShippingMarkPage(hcIndex, itemIndex, packageIndex), description)
-              .setValue(CustomsUnionAndStatisticsCodePage(hcIndex, itemIndex), cusCode)
-              .setValue(CommodityCodePage(hcIndex, itemIndex), commodityCode)
-              .setValue(CombinedNomenclatureCodePage(hcIndex, itemIndex), nomenclatureCode)
-              .setValue(DocumentReferenceNumberPage(hcIndex, itemIndex, Index(0)), "doc 1 ref")
-              .setValue(DocumentReferenceNumberPage(hcIndex, itemIndex, Index(1)), "doc 2 ref")
-              .setValue(AdditionalReferencePage(hcIndex, itemIndex, additionalReferenceIndex), additionalReference)
-              .setValue(HouseConsignmentAdditionalInformationCodePage(hcIndex, itemIndex, additionalInformationIndex), additionalInformation)
-              .setValue(ItemConsigneeNamePage(hcIndex, itemIndex), "John Smith")
-              .setValue(ItemConsigneeIdentifierPage(hcIndex, itemIndex), "csgee1")
+        val description           = Gen.alphaNumStr.sample.value
+        val grossWeight           = arbitrary[BigDecimal].sample.value
+        val netWeight             = arbitrary[Double].sample.value
+        val packageType           = arbitrary[PackageType].sample.value
+        val count                 = arbitrary[BigInt].sample.value
+        val additionalReference   = arbitrary[AdditionalReferenceType].sample.value
+        val cusCode               = "cusCode"
+        val commodityCode         = "commodityCode"
+        val nomenclatureCode      = "nomenclatureCode"
+        val additionalInformation = AdditionalInformationCode("code", "description")
 
-            val helper = new HouseConsignmentAnswersHelper(answers, hcIndex)
-            val result = helper.itemSection
+        val answers = emptyUserAnswers
+          .setValue(ItemDescriptionPage(hcIndex, itemIndex), description)
+          .setValue(GrossWeightPage(hcIndex, itemIndex), grossWeight)
+          .setValue(NetWeightPage(hcIndex, itemIndex), netWeight)
+          .setValue(PackageTypePage(hcIndex, itemIndex, packageIndex), packageType)
+          .setValue(NumberOfPackagesPage(hcIndex, itemIndex, packageIndex), count)
+          .setValue(PackageShippingMarkPage(hcIndex, itemIndex, packageIndex), description)
+          .setValue(CustomsUnionAndStatisticsCodePage(hcIndex, itemIndex), cusCode)
+          .setValue(CommodityCodePage(hcIndex, itemIndex), commodityCode)
+          .setValue(CombinedNomenclatureCodePage(hcIndex, itemIndex), nomenclatureCode)
+          .setValue(DocumentReferenceNumberPage(hcIndex, itemIndex, Index(0)), "doc 1 ref")
+          .setValue(DocumentReferenceNumberPage(hcIndex, itemIndex, Index(1)), "doc 2 ref")
+          .setValue(AdditionalReferencePage(hcIndex, itemIndex, additionalReferenceIndex), additionalReference)
+          .setValue(HouseConsignmentAdditionalInformationCodePage(hcIndex, itemIndex, additionalInformationIndex), additionalInformation)
+          .setValue(ItemConsigneeNamePage(hcIndex, itemIndex), "John Smith")
+          .setValue(ItemConsigneeIdentifierPage(hcIndex, itemIndex), "csgee1")
+          .setValue(DangerousGoodsPage(hcIndex, itemIndex, Index(0)), "dg1")
+          .setValue(DangerousGoodsPage(hcIndex, itemIndex, Index(1)), "dg2")
 
-            result.viewLinks.length mustBe 1
+        val helper = new HouseConsignmentAnswersHelper(answers, hcIndex)
+        val result = helper.itemSection
 
-            result.viewLinks.head.href mustBe "#"
-            result.viewLinks.head.id mustBe "add-remove-items"
-            result.viewLinks.head.text mustBe "Add or remove item"
+        result.viewLinks.length mustBe 1
 
-            result mustBe a[AccordionSection]
-            result.sectionTitle.value mustBe "Items"
-            result.rows.size mustBe 0
-            result.id.value mustBe "items"
+        result.viewLinks.head.href mustBe "#"
+        result.viewLinks.head.id mustBe "add-remove-items"
+        result.viewLinks.head.text mustBe "Add or remove item"
 
-            result.children.head mustBe a[AccordionSection]
-            result.children.head.sectionTitle.value mustBe "Item 1"
-            result.children.head.id.value mustBe "item-1"
-            result.children.head.rows.size mustBe 6
-            result.children.head.rows.head.value.value mustBe description
-            result.children.head.rows(1).value.value mustBe s"${grossWeight}kg"
-            result.children.head.rows(2).value.value mustBe s"${netWeight}kg"
-            result.children.head.rows(3).value.value mustBe s"$cusCode"
-            result.children.head.rows(4).value.value mustBe s"$commodityCode"
-            result.children.head.rows(5).value.value mustBe s"$nomenclatureCode"
+        result mustBe a[AccordionSection]
+        result.sectionTitle.value mustBe "Items"
+        result.rows.size mustBe 0
+        result.id.value mustBe "items"
 
-            result.children.head.children.head.sectionTitle.get mustBe "Consignee"
-            result.children.head.children.head.rows.size mustBe 2
-            result.children.head.children.head.rows.head.value.value mustBe "csgee1"
-            result.children.head.children.head.rows(1).value.value mustBe "John Smith"
+        result.children.head mustBe a[AccordionSection]
+        result.children.head.sectionTitle.value mustBe "Item 1"
+        result.children.head.id.value mustBe "item-1"
+        result.children.head.rows.size mustBe 6
+        result.children.head.rows.head.value.value mustBe description
+        result.children.head.rows(1).value.value mustBe s"${grossWeight}kg"
+        result.children.head.rows(2).value.value mustBe s"${netWeight}kg"
+        result.children.head.rows(3).value.value mustBe s"$cusCode"
+        result.children.head.rows(4).value.value mustBe s"$commodityCode"
+        result.children.head.rows(5).value.value mustBe s"$nomenclatureCode"
 
-            result.children.head.children(1) mustBe a[AccordionSection]
-            result.children.head.children(1).sectionTitle.value mustBe "Documents"
-            result.children.head.children(1).id.value mustBe "item-1-documents"
-            result.children.head.children(1).rows.size mustBe 0
-            result.children.head.children(1).viewLinks must not be empty
+        result.children.head.children.head.sectionTitle.get mustBe "UN numbers"
+        result.children.head.children.head.rows.size mustBe 2
+        result.children.head.children.head.rows.head.value.value mustBe "dg1"
+        result.children.head.children.head.rows(1).value.value mustBe "dg2"
 
-            result.children.head.children(1).children.head mustBe a[AccordionSection]
-            result.children.head.children(1).children.head.sectionTitle.value mustBe "Document 1"
-            result.children.head.children(1).children.head.id.value mustBe "item-1-document-1"
-            result.children.head.children(1).children.head.rows.size mustBe 1
-            result.children.head.children(1).children.head.rows.head.value.value mustBe "doc 1 ref"
+        result.children.head.children(1).sectionTitle.get mustBe "Consignee"
+        result.children.head.children(1).rows.size mustBe 2
+        result.children.head.children(1).rows.head.value.value mustBe "csgee1"
+        result.children.head.children(1).rows(1).value.value mustBe "John Smith"
 
-            result.children.head.children(1).children(1) mustBe a[AccordionSection]
-            result.children.head.children(1).children(1).sectionTitle.value mustBe "Document 2"
-            result.children.head.children(1).children(1).id.value mustBe "item-1-document-2"
-            result.children.head.children(1).children(1).rows.size mustBe 1
-            result.children.head.children(1).children(1).rows.head.value.value mustBe "doc 2 ref"
+        result.children.head.children(2) mustBe a[AccordionSection]
+        result.children.head.children(2).sectionTitle.value mustBe "Documents"
+        result.children.head.children(2).id.value mustBe "item-1-documents"
+        result.children.head.children(2).rows.size mustBe 0
+        result.children.head.children(2).viewLinks must not be empty
 
-            result.children.head.children(2) mustBe a[AccordionSection]
-            result.children.head.children(2).sectionTitle.value mustBe "Additional references"
-            result.children.head.children(2).id.value mustBe "item-1-additional-references"
-            result.children.head.children(2).rows.size mustBe 0
-            result.children.head.children(2).viewLinks must not be empty
+        result.children.head.children(2).children.head mustBe a[AccordionSection]
+        result.children.head.children(2).children.head.sectionTitle.value mustBe "Document 1"
+        result.children.head.children(2).children.head.id.value mustBe "item-1-document-1"
+        result.children.head.children(2).children.head.rows.size mustBe 1
+        result.children.head.children(2).children.head.rows.head.value.value mustBe "doc 1 ref"
 
-            result.children.head.children(2).children.head mustBe a[AccordionSection]
-            result.children.head.children(2).children.head.sectionTitle.value mustBe "Additional reference 1"
-            result.children.head.children(2).children.head.id.value mustBe "item-1-additional-reference-1"
-            result.children.head.children(2).children.head.rows.size mustBe 1
-            result.children.head.children(2).children.head.rows.head.value.value mustBe additionalReference.toString
+        result.children.head.children(2).children(1) mustBe a[AccordionSection]
+        result.children.head.children(2).children(1).sectionTitle.value mustBe "Document 2"
+        result.children.head.children(2).children(1).id.value mustBe "item-1-document-2"
+        result.children.head.children(2).children(1).rows.size mustBe 1
+        result.children.head.children(2).children(1).rows.head.value.value mustBe "doc 2 ref"
 
-            result.children.head.children(3) mustBe a[AccordionSection]
-            result.children.head.children(3).sectionTitle.value mustBe "Additional information"
-            result.children.head.children(3).id.value mustBe "item-1-additional-information"
-            result.children.head.children(3).rows.size mustBe 0
-            result.children.head.children(3).viewLinks mustBe empty
+        result.children.head.children(3) mustBe a[AccordionSection]
+        result.children.head.children(3).sectionTitle.value mustBe "Additional references"
+        result.children.head.children(3).id.value mustBe "item-1-additional-references"
+        result.children.head.children(3).rows.size mustBe 0
+        result.children.head.children(3).viewLinks must not be empty
 
-            result.children.head.children(3).children.head mustBe a[AccordionSection]
-            result.children.head.children(3).children.head.sectionTitle.value mustBe "Additional information 1"
-            result.children.head.children(3).children.head.id.value mustBe "item-1-additional-information-1"
-            result.children.head.children(3).children.head.rows.size mustBe 1
-            result.children.head.children(3).children.head.rows.head.value.value mustBe additionalInformation.toString
+        result.children.head.children(3).children.head mustBe a[AccordionSection]
+        result.children.head.children(3).children.head.sectionTitle.value mustBe "Additional reference 1"
+        result.children.head.children(3).children.head.id.value mustBe "item-1-additional-reference-1"
+        result.children.head.children(3).children.head.rows.size mustBe 1
+        result.children.head.children(3).children.head.rows.head.value.value mustBe additionalReference.toString
 
-            result.children.head.children(4) mustBe a[AccordionSection]
-            result.children.head.children(4).sectionTitle.value mustBe "Packages"
-            result.children.head.children(4).id.value mustBe "item-1-packages"
-            result.children.head.children(4).rows.size mustBe 0
-            result.children.head.children(4).viewLinks must not be empty
+        result.children.head.children(4) mustBe a[AccordionSection]
+        result.children.head.children(4).sectionTitle.value mustBe "Additional information"
+        result.children.head.children(4).id.value mustBe "item-1-additional-information"
+        result.children.head.children(4).rows.size mustBe 0
+        result.children.head.children(4).viewLinks mustBe empty
 
-            result.children.head.children(4).children.head.sectionTitle.get mustBe "Package 1"
-            result.children.head.children(4).children.head.id.get mustBe "item-1-package-1"
-            result.children.head.children(4).children.head.rows.size mustBe 3
-            result.children.head.children(4).children.head.rows(0).value.value mustBe s"${packageType.asDescription}"
-            result.children.head.children(4).children.head.rows(1).value.value mustBe s"$count"
-            result.children.head.children(4).children.head.rows(2).value.value mustBe s"$description"
-        }
+        result.children.head.children(4).children.head mustBe a[AccordionSection]
+        result.children.head.children(4).children.head.sectionTitle.value mustBe "Additional information 1"
+        result.children.head.children(4).children.head.id.value mustBe "item-1-additional-information-1"
+        result.children.head.children(4).children.head.rows.size mustBe 1
+        result.children.head.children(4).children.head.rows.head.value.value mustBe additionalInformation.toString
+
+        result.children.head.children(5) mustBe a[AccordionSection]
+        result.children.head.children(5).sectionTitle.value mustBe "Packages"
+        result.children.head.children(5).id.value mustBe "item-1-packages"
+        result.children.head.children(5).rows.size mustBe 0
+        result.children.head.children(5).viewLinks must not be empty
+
+        result.children.head.children(5).children.head.sectionTitle.get mustBe "Package 1"
+        result.children.head.children(5).children.head.id.get mustBe "item-1-package-1"
+        result.children.head.children(5).children.head.rows.size mustBe 3
+        result.children.head.children(5).children.head.rows(0).value.value mustBe s"${packageType.asDescription}"
+        result.children.head.children(5).children.head.rows(1).value.value mustBe s"$count"
+        result.children.head.children(5).children.head.rows(2).value.value mustBe s"$description"
       }
     }
   }

--- a/test/utils/answersHelpers/consignment/IncidentAnswersHelperSpec.scala
+++ b/test/utils/answersHelpers/consignment/IncidentAnswersHelperSpec.scala
@@ -16,7 +16,7 @@
 
 package utils.answersHelpers.consignment
 
-import generated.{AddressType18, ConsignmentType05, EndorsementType03, Flag, GNSSType, IncidentType04, LocationType02, Number0, TranshipmentType02}
+import generated._
 import models.Coordinates
 import models.departureTransportMeans.TransportMeansIdentification
 import models.reference.{Country, Incident, QualifierOfIdentification}
@@ -383,6 +383,64 @@ class IncidentAnswersHelperSpec extends AnswersHelperSpecBase {
               result.value.value mustBe unLocode
               val action = result.actions
               action mustBe None
+          }
+        }
+      }
+    }
+
+    "incidentTransportEquipments" - {
+      "when no transport equipment" - {
+        "must return None" in {
+          val helper = new IncidentAnswersHelper(emptyUserAnswers, index)
+          val result = helper.incidentTransportEquipments
+          result must not be defined
+        }
+      }
+
+      "when there are transport equipment" - {
+        "must return Some" in {
+          val transportEquipment = TransportEquipmentType07(
+            sequenceNumber = "1",
+            containerIdentificationNumber = Some("cin"),
+            numberOfSeals = Some(2),
+            Seal = Seq(
+              SealType04(
+                sequenceNumber = "1",
+                identifier = "seal1"
+              ),
+              SealType04(
+                sequenceNumber = "2",
+                identifier = "seal2"
+              )
+            ),
+            GoodsReference = Seq(
+              GoodsReferenceType01(
+                sequenceNumber = "1",
+                declarationGoodsItemNumber = 1
+              ),
+              GoodsReferenceType01(
+                sequenceNumber = "2",
+                declarationGoodsItemNumber = 2
+              )
+            )
+          )
+
+          forAll(arbitrary[IncidentType04]) {
+            incident =>
+              val consignment: ConsignmentType05 = ConsignmentType05(
+                containerIndicator = Number0,
+                Incident = Seq(incident.copy(TransportEquipment = Seq(transportEquipment)))
+              )
+
+              val answers = emptyUserAnswers.copy(ie043Data = emptyUserAnswers.ie043Data.copy(Consignment = Some(consignment)))
+
+              val helper = new IncidentAnswersHelper(answers, index)
+              val result = helper.incidentTransportEquipments.value
+              result.sectionTitle.value mustBe "Transport equipment"
+
+              result.children.size mustBe 1
+
+              result.children.head.sectionTitle.value mustBe "Transport equipment 1"
           }
         }
       }

--- a/test/utils/answersHelpers/consignment/IncidentTransportEquipmentAnswersHelperSpec.scala
+++ b/test/utils/answersHelpers/consignment/IncidentTransportEquipmentAnswersHelperSpec.scala
@@ -68,14 +68,19 @@ class IncidentTransportEquipmentAnswersHelperSpec extends AnswersHelperSpecBase 
         val helper: IncidentTransportEquipmentAnswersHelper = new IncidentTransportEquipmentAnswersHelper(mockUserAnswers, mockTransportEquipmentType)
         when(mockTransportEquipmentType.Seal).thenReturn(Seq(SealType04("1", "Seal1"), SealType04("2", "Seal2")))
 
-        val result = helper.transportEquipmentSeals
+        val result = helper.transportEquipmentSeals.value
 
-        result.size mustBe 2
-        result.head.value.value mustBe "Seal1"
-        result(1).value.value mustBe "Seal2"
-        result.head.actions must not be defined
-        result(1).actions must not be defined
+        result.sectionTitle.value mustBe "Seals"
 
+        result.rows.size mustBe 2
+
+        result.rows.head.key.value mustBe "Seal 1"
+        result.rows.head.value.value mustBe "Seal1"
+        result.rows.head.actions must not be defined
+
+        result.rows(1).key.value mustBe "Seal 2"
+        result.rows(1).value.value mustBe "Seal2"
+        result.rows(1).actions must not be defined
       }
     }
 
@@ -85,17 +90,20 @@ class IncidentTransportEquipmentAnswersHelperSpec extends AnswersHelperSpecBase 
         val helper: IncidentTransportEquipmentAnswersHelper = new IncidentTransportEquipmentAnswersHelper(mockUserAnswers, mockTransportEquipmentType)
         when(mockTransportEquipmentType.GoodsReference).thenReturn(Seq(GoodsReferenceType01("1", 123), GoodsReferenceType01("2", 234)))
 
-        val result = helper.itemNumber
+        val result = helper.itemNumbers.value
 
-        result.size mustBe 2
-        result.head.value.value mustBe "123"
-        result(1).value.value mustBe "234"
-        result.head.actions must not be defined
-        result(1).actions must not be defined
+        result.sectionTitle.value mustBe "Goods item numbers"
 
+        result.rows.size mustBe 2
+
+        result.rows.head.key.value mustBe "Goods item number 1"
+        result.rows.head.value.value mustBe "123"
+        result.rows.head.actions must not be defined
+
+        result.rows(1).key.value mustBe "Goods item number 2"
+        result.rows(1).value.value mustBe "234"
+        result.rows(1).actions must not be defined
       }
     }
-
   }
-
 }

--- a/test/utils/answersHelpers/consignment/houseConsignment/ConsignmentItemAnswersHelperSpec.scala
+++ b/test/utils/answersHelpers/consignment/houseConsignment/ConsignmentItemAnswersHelperSpec.scala
@@ -320,5 +320,29 @@ class ConsignmentItemAnswersHelperSpec extends AnswersHelperSpecBase {
         }
       }
     }
+
+    "dangerousGoodsSection" - {
+      "must generate accordion section" in {
+        forAll(Gen.alphaNumStr, Gen.alphaNumStr) {
+          (value1, value2) =>
+            val answers = emptyUserAnswers
+              .setValue(DangerousGoodsPage(hcIndex, itemIndex, Index(0)), value1)
+              .setValue(DangerousGoodsPage(hcIndex, itemIndex, Index(1)), value2)
+
+            val helper = new ConsignmentItemAnswersHelper(answers, hcIndex, itemIndex)
+            val result = helper.dangerousGoodsSection.value
+
+            result mustBe a[AccordionSection]
+            result.sectionTitle.value mustBe "UN numbers"
+            result.id.value mustBe "item-1-dangerous-goods"
+
+            result.viewLinks mustBe empty
+
+            result.rows.size mustBe 2
+            result.rows.head.value.value mustBe value1
+            result.rows(1).value.value mustBe value2
+        }
+      }
+    }
   }
 }

--- a/test/viewModels/HouseConsignmentViewModelSpec.scala
+++ b/test/viewModels/HouseConsignmentViewModelSpec.scala
@@ -56,8 +56,12 @@ class HouseConsignmentViewModelSpec extends SpecBase with AppWithDefaultMockFixt
         val result            = viewModelProvider.apply(answers, index)
         val section           = result.sections.head
 
-        section.sectionTitle.value mustBe "Departure means of transport 1"
-        section.rows.size mustBe 3
+        section.sectionTitle.value mustBe "Departure means of transport"
+        section.children.size mustBe 1
+
+        section.children.head.sectionTitle.value mustBe "Departure means of transport 1"
+        section.children.head.rows.size mustBe 3
+
         section.viewLinks mustBe Nil
       }
 
@@ -75,16 +79,18 @@ class HouseConsignmentViewModelSpec extends SpecBase with AppWithDefaultMockFixt
 
         val viewModelProvider = new HouseConsignmentViewModelProvider()
         val result            = viewModelProvider.apply(answers, index)
-        val section1          = result.sections.head
-        val section2          = result.sections(1)
+        val section           = result.sections.head
 
-        section1.sectionTitle.value mustBe "Departure means of transport 1"
-        section1.rows.size mustBe 3
-        section1.viewLinks mustBe Nil
+        section.sectionTitle.value mustBe "Departure means of transport"
+        section.children.size mustBe 2
 
-        section2.sectionTitle.value mustBe "Departure means of transport 2"
-        section2.rows.size mustBe 3
-        section1.viewLinks mustBe Nil
+        section.children.head.sectionTitle.value mustBe "Departure means of transport 1"
+        section.children.head.rows.size mustBe 3
+
+        section.children(1).sectionTitle.value mustBe "Departure means of transport 2"
+        section.children(1).rows.size mustBe 3
+
+        section.viewLinks mustBe Nil
       }
     }
 
@@ -106,22 +112,24 @@ class HouseConsignmentViewModelSpec extends SpecBase with AppWithDefaultMockFixt
         val viewModelProvider = new HouseConsignmentViewModelProvider()
         val result            = viewModelProvider.apply(userAnswers, index)
 
-        result.sections.head mustBe a[AccordionSection]
-        result.sections.head.sectionTitle.value mustBe "Items"
-        result.sections.head.viewLinks must not be empty
+        result.sections.head mustBe a[StaticSection]
+        result.sections.head.sectionTitle.value mustBe "Departure means of transport"
 
-        result.sections.head.children.head mustBe a[AccordionSection]
-        result.sections.head.children.head.sectionTitle.value mustBe "Item 1"
-        result.sections.head.children.head.rows.size mustBe 5
+        result.sections(1) mustBe a[AccordionSection]
+        result.sections(1).sectionTitle.value mustBe "Items"
+        result.sections(1).viewLinks must not be empty
 
-        result.sections.head.children.head.children.head mustBe a[StaticSection]
-        result.sections.head.children.head.children.head.sectionTitle.value mustBe "Consignee"
-        result.sections.head.children.head.children.head.rows.size mustBe 2
+        result.sections(1).children.head mustBe a[AccordionSection]
+        result.sections(1).children.head.sectionTitle.value mustBe "Item 1"
+        result.sections(1).children.head.rows.size mustBe 5
 
-        result.sections.head.children.head.children(1) mustBe a[StaticSection]
-        result.sections.head.children.head.children(1).sectionTitle.value mustBe "Documents"
-        result.sections.head.children.head.children(1).viewLinks.head.id mustBe "add-remove-item-1-document"
+        result.sections(1).children.head.children.head mustBe a[StaticSection]
+        result.sections(1).children.head.children.head.sectionTitle.value mustBe "Consignee"
+        result.sections(1).children.head.children.head.rows.size mustBe 2
 
+        result.sections(1).children.head.children(1) mustBe a[StaticSection]
+        result.sections(1).children.head.children(1).sectionTitle.value mustBe "Documents"
+        result.sections(1).children.head.children(1).viewLinks.head.id mustBe "add-remove-item-1-document"
       }
     }
 
@@ -136,7 +144,7 @@ class HouseConsignmentViewModelSpec extends SpecBase with AppWithDefaultMockFixt
 
         val viewModelProvider = new HouseConsignmentViewModelProvider()
         val result            = viewModelProvider.apply(userAnswers, index)
-        val section           = result.sections.head
+        val section           = result.sections(1)
 
         section.sectionTitle.value mustBe "Items"
         section.children.head.sectionTitle.value mustBe "Item 1"
@@ -165,21 +173,21 @@ class HouseConsignmentViewModelSpec extends SpecBase with AppWithDefaultMockFixt
         val viewModelProvider = new HouseConsignmentViewModelProvider()
         val result            = viewModelProvider.apply(userAnswers, index)
 
-        result.sections.head mustBe a[AccordionSection]
-        result.sections.head.sectionTitle.value mustBe "Items"
-        result.sections.head.viewLinks must not be empty
+        result.sections(1) mustBe a[AccordionSection]
+        result.sections(1).sectionTitle.value mustBe "Items"
+        result.sections(1).viewLinks must not be empty
 
-        result.sections.head.children.head mustBe a[AccordionSection]
-        result.sections.head.children.head.sectionTitle.value mustBe "Item 1"
-        result.sections.head.children.head.rows.size mustBe 5
+        result.sections(1).children.head mustBe a[AccordionSection]
+        result.sections(1).children.head.sectionTitle.value mustBe "Item 1"
+        result.sections(1).children.head.rows.size mustBe 5
 
-        result.sections.head.children(1) mustBe a[AccordionSection]
-        result.sections.head.children(1).sectionTitle.value mustBe "Item 2"
-        result.sections.head.children(1).rows.size mustBe 5
+        result.sections(1).children(1) mustBe a[AccordionSection]
+        result.sections(1).children(1).sectionTitle.value mustBe "Item 2"
+        result.sections(1).children(1).rows.size mustBe 5
 
-        result.sections.head.children.head.children.head mustBe a[StaticSection]
-        result.sections.head.children.head.children.head.sectionTitle.value mustBe "Consignee"
-        result.sections.head.children.head.children.head.rows.size mustBe 2
+        result.sections(1).children.head.children.head mustBe a[StaticSection]
+        result.sections(1).children.head.children.head.sectionTitle.value mustBe "Consignee"
+        result.sections(1).children.head.children.head.rows.size mustBe 2
       }
     }
   }

--- a/test/viewModels/HouseConsignmentViewModelSpec.scala
+++ b/test/viewModels/HouseConsignmentViewModelSpec.scala
@@ -112,7 +112,7 @@ class HouseConsignmentViewModelSpec extends SpecBase with AppWithDefaultMockFixt
         val viewModelProvider = new HouseConsignmentViewModelProvider()
         val result            = viewModelProvider.apply(userAnswers, index)
 
-        result.sections.head mustBe a[StaticSection]
+        result.sections.head mustBe a[AccordionSection]
         result.sections.head.sectionTitle.value mustBe "Departure means of transport"
 
         result.sections(1) mustBe a[AccordionSection]
@@ -127,7 +127,7 @@ class HouseConsignmentViewModelSpec extends SpecBase with AppWithDefaultMockFixt
         result.sections(1).children.head.children.head.sectionTitle.value mustBe "Consignee"
         result.sections(1).children.head.children.head.rows.size mustBe 2
 
-        result.sections(1).children.head.children(1) mustBe a[StaticSection]
+        result.sections(1).children.head.children(1) mustBe a[AccordionSection]
         result.sections(1).children.head.children(1).sectionTitle.value mustBe "Documents"
         result.sections(1).children.head.children(1).viewLinks.head.id mustBe "add-remove-item-1-document"
       }

--- a/test/viewModels/UnloadingFindingsViewModelSpec.scala
+++ b/test/viewModels/UnloadingFindingsViewModelSpec.scala
@@ -488,11 +488,14 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
         section.children.length mustBe 1
 
         section.children.head.sectionTitle.value mustBe "House consignment 1"
-        section.children.head.rows.size mustBe 2
+        section.children.head.rows.size mustBe 0
         section.children.head.viewLinks.size mustBe 1
 
-        section.children.head.children.head.sectionTitle.value mustBe "Consignee"
+        section.children.head.children.head.sectionTitle.value mustBe "Consignor"
         section.children.head.children.head.rows.size mustBe 2
+
+        section.children.head.children(1).sectionTitle.value mustBe "Consignee"
+        section.children.head.children(1).rows.size mustBe 2
       }
       "when there is multiple" in {
         val userAnswers = emptyUserAnswers
@@ -525,11 +528,14 @@ class UnloadingFindingsViewModelSpec extends SpecBase with AppWithDefaultMockFix
         section.children.length mustBe 2
 
         section.children.head.sectionTitle.value mustBe "House consignment 1"
-        section.children.head.rows.size mustBe 2
+        section.children.head.rows.size mustBe 0
         section.children.head.viewLinks.size mustBe 1
 
-        section.children.head.children.head.sectionTitle.value mustBe "Consignee"
+        section.children.head.children.head.sectionTitle.value mustBe "Consignor"
         section.children.head.children.head.rows.size mustBe 2
+
+        section.children.head.children(1).sectionTitle.value mustBe "Consignee"
+        section.children.head.children(1).rows.size mustBe 2
       }
     }
 


### PR DESCRIPTION
- Simplified indentation for a more consistent structure
- UN number moved into parent accordion
- Empty accordions will still display as an accordion
- Item departure transport means moved into parent accordion

<img width="242" alt="Screenshot 2024-03-22 at 07 51 12" src="https://github.com/hmrc/manage-transit-movements-unloading-frontend/assets/43777106/6d6122c6-09c6-483c-a09f-e9e53cc64bdf">

---

- Moved incident transport equipment into parent accordions
- Moved incident transport equipment seals and goods item numbers into parent accordions

<img width="233" alt="Screenshot 2024-03-22 at 08 49 35" src="https://github.com/hmrc/manage-transit-movements-unloading-frontend/assets/43777106/2238d1ed-d4fa-4ff6-b22d-e5969b6d743a">

---

Indentation reviewed by Nigel. Subsequently added `govuk-!-margin-bottom-9` for a `StaticSection`.

<img width="1092" alt="Screenshot 2024-03-22 at 08 51 48" src="https://github.com/hmrc/manage-transit-movements-unloading-frontend/assets/43777106/030e0d7b-1ced-43e8-a341-52e5db13a55b">

