### PR TITLE
Reverting to RFC37 XSDs.

### DIFF
--- a/app/models/Document.scala
+++ b/app/models/Document.scala
@@ -30,7 +30,7 @@ object Document {
 
   def apply(document: SupportingDocumentType02, documentType: DocumentType): SupportingDocument =
     SupportingDocument(
-      sequenceNumber = document.sequenceNumber,
+      sequenceNumber = BigInt(document.sequenceNumber),
       documentType = DocumentType(
         `type` = Support,
         code = documentType.code,
@@ -42,7 +42,7 @@ object Document {
 
   def apply(document: TransportDocumentType02, documentType: DocumentType): TransportDocument =
     TransportDocument(
-      sequenceNumber = document.sequenceNumber,
+      sequenceNumber = BigInt(document.sequenceNumber),
       documentType = DocumentType(
         `type` = Transport,
         code = documentType.code,
@@ -53,7 +53,7 @@ object Document {
 
   def apply(document: PreviousDocumentType06, documentType: DocumentType): PreviousDocument =
     PreviousDocument(
-      sequenceNumber = document.sequenceNumber,
+      sequenceNumber = BigInt(document.sequenceNumber),
       documentType = DocumentType(
         `type` = Previous,
         code = documentType.code,
@@ -65,7 +65,7 @@ object Document {
 
   def apply(document: PreviousDocumentType04, documentType: DocumentType): PreviousDocument =
     PreviousDocument(
-      sequenceNumber = document.sequenceNumber,
+      sequenceNumber = BigInt(document.sequenceNumber),
       documentType = DocumentType(
         `type` = Previous,
         code = documentType.code,

--- a/app/models/package.scala
+++ b/app/models/package.scala
@@ -182,7 +182,7 @@ package object models {
     def toXML: NodeSeq = scalaxb.toXML(value, CC043C.toString, toScope())
 
     def preparationDateAndTime: LocalDate =
-      value.messageSequence1.preparationDateAndTime.toLocalDate
+      value.messageSequence1.messagE_1Sequence2.preparationDateAndTime.toLocalDate
 
     def sealsExist: Boolean =
       value.Consignment.exists {

--- a/app/pages/additionalReference/AdditionalReferenceNumberPage.scala
+++ b/app/pages/additionalReference/AdditionalReferenceNumberPage.scala
@@ -31,7 +31,7 @@ case class AdditionalReferenceNumberPage(referenceIndex: Index) extends Discrepa
   override def valueInIE043(ie043: Seq[AdditionalReferenceType03], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .flatMap(_.referenceNumber)
 }

--- a/app/pages/additionalReference/AdditionalReferenceTypePage.scala
+++ b/app/pages/additionalReference/AdditionalReferenceTypePage.scala
@@ -32,7 +32,7 @@ case class AdditionalReferenceTypePage(referenceIndex: Index) extends Discrepanc
   override def valueInIE043(ie043: Seq[AdditionalReferenceType03], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.typeValue)
 }

--- a/app/pages/departureMeansOfTransport/CountryPage.scala
+++ b/app/pages/departureMeansOfTransport/CountryPage.scala
@@ -32,7 +32,7 @@ case class CountryPage(transportMeansIndex: Index) extends DiscrepancyQuestionPa
   override def valueInIE043(ie043: Seq[DepartureTransportMeansType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.nationality)
 }

--- a/app/pages/departureMeansOfTransport/TransportMeansIdentificationPage.scala
+++ b/app/pages/departureMeansOfTransport/TransportMeansIdentificationPage.scala
@@ -33,7 +33,7 @@ case class TransportMeansIdentificationPage(transportMeansIndex: Index)
   override def valueInIE043(ie043: Seq[DepartureTransportMeansType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.typeOfIdentification)
 }

--- a/app/pages/departureMeansOfTransport/VehicleIdentificationNumberPage.scala
+++ b/app/pages/departureMeansOfTransport/VehicleIdentificationNumberPage.scala
@@ -30,7 +30,7 @@ case class VehicleIdentificationNumberPage(transportMeansIndex: Index) extends D
   override def valueInIE043(ie043: Seq[DepartureTransportMeansType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.identificationNumber)
 }

--- a/app/pages/documents/AdditionalInformationPage.scala
+++ b/app/pages/documents/AdditionalInformationPage.scala
@@ -31,7 +31,7 @@ case class AdditionalInformationPage(documentIndex: Index) extends DiscrepancyQu
   override def valueInIE043(ie043: Seq[SupportingDocumentType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .flatMap(_.complementOfInformation)
 }

--- a/app/pages/documents/DocumentReferenceNumberPage.scala
+++ b/app/pages/documents/DocumentReferenceNumberPage.scala
@@ -43,7 +43,7 @@ case class SupportingDocumentReferenceNumberPage(documentIndex: Index) extends B
   override def valueInIE043(ie043: Seq[SupportingDocumentType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.referenceNumber)
 }
@@ -53,7 +53,7 @@ case class TransportDocumentReferenceNumberPage(documentIndex: Index) extends Ba
   override def valueInIE043(ie043: Seq[TransportDocumentType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.referenceNumber)
 }

--- a/app/pages/documents/TypePage.scala
+++ b/app/pages/documents/TypePage.scala
@@ -44,7 +44,7 @@ case class SupportingTypePage(documentIndex: Index) extends BaseTypePage[Support
   override def valueInIE043(ie043: Seq[SupportingDocumentType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.typeValue)
 }
@@ -54,7 +54,7 @@ case class TransportTypePage(documentIndex: Index) extends BaseTypePage[Transpor
   override def valueInIE043(ie043: Seq[TransportDocumentType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.typeValue)
 }

--- a/app/pages/houseConsignment/index/GrossWeightPage.scala
+++ b/app/pages/houseConsignment/index/GrossWeightPage.scala
@@ -31,7 +31,7 @@ case class GrossWeightPage(houseConsignmentIndex: Index) extends DiscrepancyQues
   override def valueInIE043(ie043: Seq[HouseConsignmentType04], sequenceNumber: Option[BigInt]): Option[BigDecimal] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.grossMass)
 }

--- a/app/pages/houseConsignment/index/additionalReference/HouseConsignmentAdditionalReferenceNumberPage.scala
+++ b/app/pages/houseConsignment/index/additionalReference/HouseConsignmentAdditionalReferenceNumberPage.scala
@@ -33,7 +33,7 @@ case class HouseConsignmentAdditionalReferenceNumberPage(houseConsignmentIndex: 
   override def valueInIE043(ie043: Seq[AdditionalReferenceType03], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .flatMap(_.referenceNumber)
 }

--- a/app/pages/houseConsignment/index/additionalReference/HouseConsignmentAdditionalReferenceTypePage.scala
+++ b/app/pages/houseConsignment/index/additionalReference/HouseConsignmentAdditionalReferenceTypePage.scala
@@ -34,7 +34,7 @@ case class HouseConsignmentAdditionalReferenceTypePage(houseConsignmentIndex: In
   override def valueInIE043(ie043: Seq[AdditionalReferenceType03], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.typeValue)
 }

--- a/app/pages/houseConsignment/index/departureMeansOfTransport/CountryPage.scala
+++ b/app/pages/houseConsignment/index/departureMeansOfTransport/CountryPage.scala
@@ -33,7 +33,7 @@ case class CountryPage(houseConsignmentIndex: Index, transportMeansIndex: Index)
   override def valueInIE043(ie043: Seq[DepartureTransportMeansType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.nationality)
 }

--- a/app/pages/houseConsignment/index/departureMeansOfTransport/TransportMeansIdentificationPage.scala
+++ b/app/pages/houseConsignment/index/departureMeansOfTransport/TransportMeansIdentificationPage.scala
@@ -33,7 +33,7 @@ case class TransportMeansIdentificationPage(houseConsignmentIndex: Index, transp
   override def valueInIE043(ie043: Seq[DepartureTransportMeansType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.typeOfIdentification)
 }

--- a/app/pages/houseConsignment/index/departureMeansOfTransport/VehicleIdentificationNumberPage.scala
+++ b/app/pages/houseConsignment/index/departureMeansOfTransport/VehicleIdentificationNumberPage.scala
@@ -32,7 +32,7 @@ case class VehicleIdentificationNumberPage(houseConsignmentIndex: Index, transpo
   override def valueInIE043(ie043: Seq[DepartureTransportMeansType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.identificationNumber)
 }

--- a/app/pages/houseConsignment/index/documents/AdditionalInformationPage.scala
+++ b/app/pages/houseConsignment/index/documents/AdditionalInformationPage.scala
@@ -32,7 +32,7 @@ case class AdditionalInformationPage(houseConsignmentIndex: Index, documentIndex
   override def valueInIE043(ie043: Seq[SupportingDocumentType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .flatMap(_.complementOfInformation)
 }

--- a/app/pages/houseConsignment/index/documents/DocumentReferenceNumberPage.scala
+++ b/app/pages/houseConsignment/index/documents/DocumentReferenceNumberPage.scala
@@ -45,7 +45,7 @@ case class SupportingDocumentReferenceNumberPage(houseConsignmentIndex: Index, d
   override def valueInIE043(ie043: Seq[SupportingDocumentType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.referenceNumber)
 }
@@ -56,7 +56,7 @@ case class TransportDocumentReferenceNumberPage(houseConsignmentIndex: Index, do
   override def valueInIE043(ie043: Seq[TransportDocumentType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.referenceNumber)
 }

--- a/app/pages/houseConsignment/index/documents/TypePage.scala
+++ b/app/pages/houseConsignment/index/documents/TypePage.scala
@@ -45,7 +45,7 @@ case class SupportingTypePage(houseConsignmentIndex: Index, documentIndex: Index
   override def valueInIE043(ie043: Seq[SupportingDocumentType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.typeValue)
 }
@@ -55,7 +55,7 @@ case class TransportTypePage(houseConsignmentIndex: Index, documentIndex: Index)
   override def valueInIE043(ie043: Seq[TransportDocumentType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.typeValue)
 }

--- a/app/pages/houseConsignment/index/items/additionalReference/AdditionalReferenceNumberPage.scala
+++ b/app/pages/houseConsignment/index/items/additionalReference/AdditionalReferenceNumberPage.scala
@@ -33,7 +33,7 @@ case class AdditionalReferenceNumberPage(houseConsignmentIndex: Index, itemIndex
   override def valueInIE043(ie043: Seq[AdditionalReferenceType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .flatMap(_.referenceNumber)
 }

--- a/app/pages/houseConsignment/index/items/additionalReference/AdditionalReferenceTypePage.scala
+++ b/app/pages/houseConsignment/index/items/additionalReference/AdditionalReferenceTypePage.scala
@@ -34,7 +34,7 @@ case class AdditionalReferenceTypePage(houseConsignmentIndex: Index, itemIndex: 
   override def valueInIE043(ie043: Seq[AdditionalReferenceType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.typeValue)
 }

--- a/app/pages/houseConsignment/index/items/document/AdditionalInformationPage.scala
+++ b/app/pages/houseConsignment/index/items/document/AdditionalInformationPage.scala
@@ -32,7 +32,7 @@ case class AdditionalInformationPage(houseConsignmentIndex: Index, itemIndex: In
   override def valueInIE043(ie043: Seq[SupportingDocumentType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .flatMap(_.complementOfInformation)
 }

--- a/app/pages/houseConsignment/index/items/document/DocumentReferenceNumberPage.scala
+++ b/app/pages/houseConsignment/index/items/document/DocumentReferenceNumberPage.scala
@@ -46,7 +46,7 @@ case class SupportingDocumentReferenceNumberPage(houseConsignmentIndex: Index, i
   override def valueInIE043(ie043: Seq[SupportingDocumentType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.referenceNumber)
 }
@@ -57,7 +57,7 @@ case class TransportDocumentReferenceNumberPage(houseConsignmentIndex: Index, it
   override def valueInIE043(ie043: Seq[TransportDocumentType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.referenceNumber)
 }

--- a/app/pages/houseConsignment/index/items/document/TypePage.scala
+++ b/app/pages/houseConsignment/index/items/document/TypePage.scala
@@ -46,7 +46,7 @@ case class SupportingTypePage(houseConsignmentIndex: Index, itemIndex: Index, do
   override def valueInIE043(ie043: Seq[SupportingDocumentType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.typeValue)
 }
@@ -56,7 +56,7 @@ case class TransportTypePage(houseConsignmentIndex: Index, itemIndex: Index, doc
   override def valueInIE043(ie043: Seq[TransportDocumentType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.typeValue)
 }

--- a/app/pages/houseConsignment/index/items/packages/NumberOfPackagesPage.scala
+++ b/app/pages/houseConsignment/index/items/packages/NumberOfPackagesPage.scala
@@ -32,7 +32,7 @@ case class NumberOfPackagesPage(houseConsignmentIndex: Index, itemIndex: Index, 
   override def valueInIE043(ie043: Seq[PackagingType02], sequenceNumber: Option[BigInt]): Option[BigInt] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .flatMap(_.numberOfPackages)
 }

--- a/app/pages/houseConsignment/index/items/packages/PackageShippingMarkPage.scala
+++ b/app/pages/houseConsignment/index/items/packages/PackageShippingMarkPage.scala
@@ -32,7 +32,7 @@ case class PackageShippingMarkPage(houseConsignmentIndex: Index, itemIndex: Inde
   override def valueInIE043(ie043: Seq[PackagingType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .flatMap(_.shippingMarks)
 }

--- a/app/pages/houseConsignment/index/items/packages/PackageTypePage.scala
+++ b/app/pages/houseConsignment/index/items/packages/PackageTypePage.scala
@@ -33,7 +33,7 @@ case class PackageTypePage(houseConsignmentIndex: Index, itemIndex: Index, packa
   override def valueInIE043(ie043: Seq[PackagingType02], sequenceNumber: Option[BigInt]): Option[String] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.typeOfPackages)
 }

--- a/app/pages/transportEquipment/index/ItemPage.scala
+++ b/app/pages/transportEquipment/index/ItemPage.scala
@@ -31,7 +31,7 @@ case class ItemPage(equipmentIndex: Index, itemIndex: Index) extends Discrepancy
   override def valueInIE043(ie043: Seq[GoodsReferenceType02], sequenceNumber: Option[BigInt]): Option[BigInt] =
     ie043
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.declarationGoodsItemNumber)
 }

--- a/app/pages/transportEquipment/index/seals/SealIdentificationNumberPage.scala
+++ b/app/pages/transportEquipment/index/seals/SealIdentificationNumberPage.scala
@@ -31,7 +31,7 @@ case class SealIdentificationNumberPage(equipmentIndex: Index, sealIndex: Index)
   override def valueInIE043(transportEquipment: Seq[SealType04], sequenceNumber: Option[BigInt]): Option[String] =
     transportEquipment
       .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
+        x => sequenceNumber.contains(BigInt(x.sequenceNumber))
       }
       .map(_.identifier)
 }

--- a/app/services/submission/SubmissionService.scala
+++ b/app/services/submission/SubmissionService.scala
@@ -79,11 +79,17 @@ class SubmissionService @Inject() (
   def messageSequence(eoriNumber: EoriNumber, officeOfDestination: String): MESSAGESequence =
     MESSAGESequence(
       messageSender = eoriNumber.value,
-      messageRecipient = s"NTA.${officeOfDestination.take(2)}",
-      preparationDateAndTime = dateTimeService.currentDateTime,
-      messageIdentification = messageIdentificationService.randomIdentifier,
-      messageType = CC044C,
-      correlationIdentifier = None
+      messagE_1Sequence2 = MESSAGE_1Sequence(
+        messageRecipient = s"NTA.${officeOfDestination.take(2)}",
+        preparationDateAndTime = dateTimeService.currentDateTime,
+        messageIdentification = messageIdentificationService.randomIdentifier
+      ),
+      messagE_TYPESequence3 = MESSAGE_TYPESequence(
+        messageType = CC044C
+      ),
+      correlatioN_IDENTIFIERSequence4 = CORRELATION_IDENTIFIERSequence(
+        correlationIdentifier = None
+      )
     )
 
   def transitOperationReads(userAnswers: UserAnswers): Reads[TransitOperationType15] = {
@@ -193,7 +199,7 @@ class SubmissionService @Inject() (
         }
       }
 
-    lazy val transportEquipment = ie043.find(_.sequenceNumber == sequenceNumber)
+    lazy val transportEquipment = ie043.find(_.sequenceNumber == sequenceNumber.toString())
     lazy val seals              = transportEquipment.getList(_.Seal)
     lazy val goodsReferences    = transportEquipment.getList(_.GoodsReference)
 
@@ -379,7 +385,7 @@ class SubmissionService @Inject() (
     import pages.sections.houseConsignment.index.departureTransportMeans._
     import pages.sections.houseConsignment.index.documents._
 
-    lazy val houseConsignment        = ie043.find(_.sequenceNumber == sequenceNumber)
+    lazy val houseConsignment        = ie043.find(_.sequenceNumber == sequenceNumber.toString())
     lazy val departureTransportMeans = houseConsignment.getList(_.DepartureTransportMeans)
     lazy val supportingDocuments     = houseConsignment.getList(_.SupportingDocument)
     lazy val transportDocuments      = houseConsignment.getList(_.TransportDocument)
@@ -582,7 +588,7 @@ class SubmissionService @Inject() (
     import pages.sections.houseConsignment.index.items.additionalReference._
     import pages.sections.houseConsignment.index.items.documents.DocumentsSection
 
-    lazy val consignmentItem      = ie043.find(_.goodsItemNumber == sequenceNumber)
+    lazy val consignmentItem      = ie043.find(_.goodsItemNumber == sequenceNumber.toString())
     lazy val commodity            = consignmentItem.map(_.Commodity)
     lazy val packaging            = consignmentItem.getList(_.Packaging)
     lazy val supportingDocuments  = consignmentItem.getList(_.SupportingDocument)
@@ -644,7 +650,7 @@ class SubmissionService @Inject() (
     import pages.houseConsignment.index.items._
 
     lazy val commodityCode = ie043.flatMap(_.CommodityCode)
-    lazy val goodsMeasure  = ie043.map(_.GoodsMeasure)
+    lazy val goodsMeasure  = ie043.flatMap(_.GoodsMeasure)
 
     def commodityCodeReads(ie043: Option[CommodityCodeType05]): Reads[Option[CommodityCodeType03]] =
       for {

--- a/app/services/submission/package.scala
+++ b/app/services/submission/package.scala
@@ -91,4 +91,6 @@ package object submission {
 
     def getList[B](f: A => Seq[B]): Seq[B] = value.map(f).getOrElse(Seq.empty)
   }
+
+  implicit def bigIntToString(value: BigInt): String = value.toString()
 }

--- a/app/utils/transformers/GoodsMeasureTransformer.scala
+++ b/app/utils/transformers/GoodsMeasureTransformer.scala
@@ -25,13 +25,15 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class GoodsMeasureTransformer @Inject() (implicit ec: ExecutionContext) extends PageTransformer {
 
-  def transform(goodsMeasure: GoodsMeasureType03, hcIndex: Index, itemIndex: Index): UserAnswers => Future[UserAnswers] = userAnswers =>
+  def transform(goodsMeasure: Option[GoodsMeasureType03], hcIndex: Index, itemIndex: Index): UserAnswers => Future[UserAnswers] = userAnswers =>
     goodsMeasure match {
-      case GoodsMeasureType03(grossMass, netMass) =>
+      case Some(GoodsMeasureType03(grossMass, netMass)) =>
         val pipeline: UserAnswers => Future[UserAnswers] =
           set(GrossWeightPage(hcIndex, itemIndex), grossMass) andThen
             set(NetWeightPage(hcIndex, itemIndex), netMass)
 
         pipeline(userAnswers)
+      case None =>
+        Future.successful(userAnswers)
     }
 }

--- a/app/utils/transformers/PageTransformer.scala
+++ b/app/utils/transformers/PageTransformer.scala
@@ -44,6 +44,9 @@ trait PageTransformer {
     setValue(section, SequenceNumber, sequenceNumber) andThen
       setValue(section, Removed, false)
 
+  def setSequenceNumber(section: Section[JsObject], sequenceNumber: String)(implicit ec: ExecutionContext): UserAnswers => Future[UserAnswers] =
+    setSequenceNumber(section, BigInt(sequenceNumber))
+
   private def setValue[A](section: Section[JsObject], key: String, value: A)(implicit writes: Writes[A]): UserAnswers => Future[UserAnswers] = userAnswers =>
     Future.fromTry(userAnswers.set(section.path \ key, value))
 }

--- a/conf/xsd/cc043c.xsd
+++ b/conf/xsd/cc043c.xsd
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ncts.dgtaxud.ec" xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" targetNamespace="http://ncts.dgtaxud.ec" elementFormDefault="unqualified" attributeFormDefault="unqualified" version="51.8.6" vc:minVersion="1.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ncts.dgtaxud.ec" xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" targetNamespace="http://ncts.dgtaxud.ec" elementFormDefault="unqualified" attributeFormDefault="unqualified" version="51.8.2" vc:minVersion="1.1">
   <!--================================================================================-->
   <!--===== IE043: E_ULD_PER                                                                -->
   <!--===== UNLOADING PERMISSION                                                            -->
   <!--===== NCTS P5 Phase Definition                                                        -->
-  <!--===== XSD Version 51.8.6                                                              -->
+  <!--===== XSD Version 51.8.2                                                              -->
   <!--================================================================================-->
   <!--================================================================================-->
   <!--===== Includes                                                                        -->

--- a/conf/xsd/cc044c.xsd
+++ b/conf/xsd/cc044c.xsd
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ncts.dgtaxud.ec" xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" targetNamespace="http://ncts.dgtaxud.ec" elementFormDefault="unqualified" attributeFormDefault="unqualified" version="51.8.6" vc:minVersion="1.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ncts.dgtaxud.ec" xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" targetNamespace="http://ncts.dgtaxud.ec" elementFormDefault="unqualified" attributeFormDefault="unqualified" version="51.8.2" vc:minVersion="1.1">
   <!--================================================================================-->
   <!--===== IE044: E_ULD_REM                                                                -->
   <!--===== UNLOADING REMARKS                                                               -->
   <!--===== NCTS P5 Phase Definition                                                        -->
-  <!--===== XSD Version 51.8.6                                                              -->
+  <!--===== XSD Version 51.8.2                                                              -->
   <!--================================================================================-->
   <!--================================================================================-->
   <!--===== Includes                                                                        -->

--- a/conf/xsd/ctypes.xsd
+++ b/conf/xsd/ctypes.xsd
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ncts.dgtaxud.ec" xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" targetNamespace="http://ncts.dgtaxud.ec" elementFormDefault="unqualified" attributeFormDefault="unqualified" version="51.8.6" vc:minVersion="1.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ncts.dgtaxud.ec" xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" targetNamespace="http://ncts.dgtaxud.ec" elementFormDefault="unqualified" attributeFormDefault="unqualified" version="51.8.2" vc:minVersion="1.1">
   <!--================================================================================-->
   <!--===== Complex Types                                                                   -->
-  <!--===== DDNTA 5.15.2                                                                    -->
+  <!--===== DDNTA 5.15.1                                                                    -->
   <!--===== NCTS P5 Phase Definition                                                        -->
-  <!--===== XSD version 51.8.6                                                              -->
-  <!--===== Aligned with RFC-List version DDNTA RFC-List.39                                 -->
+  <!--===== XSD version 51.8.2                                                              -->
+  <!--===== Aligned with RFC-List version DDNTA RFC-List.37                                 -->
   <!--================================================================================-->
   <!--================================================================================-->
   <!--===== Includes                                                                        -->
@@ -30,7 +30,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="AES communication purpose" />
-            <codeList code="CL158" type="business" name="XFTCommunicationPurpose" />
+            <codeList code="CL158" type="business" name="XftCommunicationPurpose" />
             <format value="n1" />
             <optionality value="R" />
           </xs:documentation>
@@ -133,7 +133,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -173,7 +172,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -191,7 +189,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Type of identification" />
-            <codeList code="CL219" type="business" name="TypeOfIdentificationofMeansOfTransportActive" />
+            <codeList code="CL219" type="business" name="TypeOfIdentificationOfMeansOfTransportActive" />
             <format value="n2" />
             <optionality value="R" />
           </xs:documentation>
@@ -243,7 +241,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -261,7 +258,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Type of identification" />
-            <codeList code="CL219" type="business" name="TypeOfIdentificationofMeansOfTransportActive" />
+            <codeList code="CL219" type="business" name="TypeOfIdentificationOfMeansOfTransportActive" />
             <format value="n2" />
             <optionality value="O" />
           </xs:documentation>
@@ -313,7 +310,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -331,7 +327,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Type of identification" />
-            <codeList code="CL219" type="business" name="TypeOfIdentificationofMeansOfTransportActive" />
+            <codeList code="CL219" type="business" name="TypeOfIdentificationOfMeansOfTransportActive" />
             <format value="n2" />
             <optionality value="R" />
           </xs:documentation>
@@ -383,7 +379,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -401,7 +396,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Type of identification" />
-            <codeList code="CL219" type="business" name="TypeOfIdentificationofMeansOfTransportActive" />
+            <codeList code="CL219" type="business" name="TypeOfIdentificationOfMeansOfTransportActive" />
             <format value="n2" />
             <optionality value="O" />
           </xs:documentation>
@@ -456,7 +451,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -505,7 +499,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -544,7 +537,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -586,7 +578,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -594,7 +585,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Type" />
-            <codeList code="CL380" type="business" name="AdditionalReference" />
+            <codeList code="CL380" type="business" name="AdditionalReferencesType" />
             <format value="an4" />
             <optionality value="O" />
           </xs:documentation>
@@ -625,7 +616,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -633,7 +623,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Type" />
-            <codeList code="CL380" type="business" name="AdditionalReference" />
+            <codeList code="CL380" type="business" name="AdditionalReferencesType" />
             <format value="an4" />
             <optionality value="R" />
           </xs:documentation>
@@ -664,7 +654,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -672,7 +661,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Type" />
-            <codeList code="CL380" type="business" name="AdditionalReference" />
+            <codeList code="CL380" type="business" name="AdditionalReferencesType" />
             <format value="an4" />
             <optionality value="R" />
           </xs:documentation>
@@ -703,7 +692,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -711,7 +699,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Type" />
-            <codeList code="CL380" type="business" name="AdditionalReference" />
+            <codeList code="CL380" type="business" name="AdditionalReferencesType" />
             <format value="an4" />
             <optionality value="R" />
           </xs:documentation>
@@ -742,7 +730,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -750,7 +737,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Type" />
-            <codeList code="CL380" type="business" name="AdditionalReference" />
+            <codeList code="CL380" type="business" name="AdditionalReferencesType" />
             <format value="an4" />
             <optionality value="R" />
           </xs:documentation>
@@ -781,7 +768,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -789,7 +775,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Type" />
-            <codeList code="CL380" type="business" name="AdditionalReference" />
+            <codeList code="CL380" type="business" name="AdditionalReferencesType" />
             <format value="an4" />
             <optionality value="O" />
           </xs:documentation>
@@ -823,7 +809,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -831,7 +816,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Role" />
-            <codeList code="CL704" type="business" name="AdditionalSupplyChainActorRoleCode" />
+            <codeList code="CL704" type="business" name="RoleOfActor" />
             <format value="a..3" />
             <optionality value="R" />
           </xs:documentation>
@@ -1884,7 +1869,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -1923,7 +1907,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -1962,7 +1945,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -2119,7 +2101,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Harmonized System sub-heading code" />
-            <codeList code="CL152" type="business" name="HScode" />
+            <codeList code="CL152" type="business" name="HsCode" />
             <format value="an6" />
             <optionality value="R" />
           </xs:documentation>
@@ -2148,7 +2130,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Harmonized System sub-heading code" />
-            <codeList code="CL152" type="business" name="HScode" />
+            <codeList code="CL152" type="business" name="HsCode" />
             <format value="an6" />
             <optionality value="R" />
           </xs:documentation>
@@ -2177,7 +2159,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Harmonized System sub-heading code" />
-            <codeList code="CL152" type="business" name="HScode" />
+            <codeList code="CL152" type="business" name="HsCode" />
             <format value="an6" />
             <optionality value="R" />
           </xs:documentation>
@@ -2206,7 +2188,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Harmonized System sub-heading code" />
-            <codeList code="CL152" type="business" name="HScode" />
+            <codeList code="CL152" type="business" name="HsCode" />
             <format value="an6" />
             <optionality value="R" />
           </xs:documentation>
@@ -2235,7 +2217,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Harmonized System sub-heading code" />
-            <codeList code="CL152" type="business" name="HScode" />
+            <codeList code="CL152" type="business" name="HsCode" />
             <format value="an6" />
             <optionality value="R" />
           </xs:documentation>
@@ -2264,7 +2246,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Harmonized System sub-heading code" />
-            <codeList code="CL152" type="business" name="HScode" />
+            <codeList code="CL152" type="business" name="HsCode" />
             <format value="an6" />
             <optionality value="R" />
           </xs:documentation>
@@ -2306,7 +2288,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="CUS code" />
-            <codeList code="CL016" type="business" name="CUSCode" />
+            <codeList code="CL016" type="business" name="CusCode" />
             <format value="an9" />
             <optionality value="O" />
           </xs:documentation>
@@ -2359,7 +2341,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="CUS code" />
-            <codeList code="CL016" type="business" name="CUSCode" />
+            <codeList code="CL016" type="business" name="CusCode" />
             <format value="an9" />
             <optionality value="O" />
           </xs:documentation>
@@ -2381,11 +2363,11 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="GoodsMeasure" type="GoodsMeasureType03">
+      <xs:element name="GoodsMeasure" minOccurs="0" type="GoodsMeasureType03"> <!--##Added minOccurs="0" as this is optional (IE029 Only)##-->
         <xs:annotation>
           <xs:documentation>
             <description value="GOODS MEASURE" />
-            <optionality value="R" />
+            <optionality value="O" />    <!--##Changed to Optional (IE025 - Not in active use in HMRC)##-->
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -2412,7 +2394,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="CUS code" />
-            <codeList code="CL016" type="business" name="CUSCode" />
+            <codeList code="CL016" type="business" name="CusCode" />
             <format value="an9" />
             <optionality value="O" />
           </xs:documentation>
@@ -2482,7 +2464,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="CUS code" />
-            <codeList code="CL016" type="business" name="CUSCode" />
+            <codeList code="CL016" type="business" name="CusCode" />
             <format value="an9" />
             <optionality value="O" />
           </xs:documentation>
@@ -2535,7 +2517,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="CUS code" />
-            <codeList code="CL016" type="business" name="CUSCode" />
+            <codeList code="CL016" type="business" name="CusCode" />
             <format value="an9" />
             <optionality value="O" />
           </xs:documentation>
@@ -2588,7 +2570,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="CUS code" />
-            <codeList code="CL016" type="business" name="CUSCode" />
+            <codeList code="CL016" type="business" name="CusCode" />
             <format value="an9" />
             <optionality value="O" />
           </xs:documentation>
@@ -2641,7 +2623,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="CUS code" />
-            <codeList code="CL016" type="business" name="CUSCode" />
+            <codeList code="CL016" type="business" name="CusCode" />
             <format value="an9" />
             <optionality value="O" />
           </xs:documentation>
@@ -2663,11 +2645,11 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="GoodsMeasure" type="GoodsMeasureType03">
+      <xs:element name="GoodsMeasure" minOccurs="0" type="GoodsMeasureType03"> <!--##Added minOccurs="0" as this is optional (IE029 Only)##-->
         <xs:annotation>
           <xs:documentation>
             <description value="GOODS MEASURE" />
-            <optionality value="R" />
+            <optionality value="O" />    <!--##Changed to Optional (IE029 & IE043)##-->
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -2684,7 +2666,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="CUS code" />
-            <codeList code="CL016" type="business" name="CUSCode" />
+            <codeList code="CL016" type="business" name="CusCode" />
             <format value="an9" />
             <optionality value="O" />
           </xs:documentation>
@@ -2721,7 +2703,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="CUS code" />
-            <codeList code="CL016" type="business" name="CUSCode" />
+            <codeList code="CL016" type="business" name="CusCode" />
             <format value="an9" />
             <optionality value="O" />
           </xs:documentation>
@@ -2774,7 +2756,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="CUS code" />
-            <codeList code="CL016" type="business" name="CUSCode" />
+            <codeList code="CL016" type="business" name="CusCode" />
             <format value="an9" />
             <optionality value="O" />
           </xs:documentation>
@@ -3347,13 +3329,12 @@
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="goodsItemNumber" type="GoodsItemNumberContentType">
+      <xs:element name="goodsItemNumber" type="GoodsItemNumberContentType02">
         <xs:annotation>
           <xs:documentation>
             <description value="Goods item number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -3384,7 +3365,7 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
+            <xsdBaseType value="Alpha_2" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -3395,7 +3376,6 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -3498,13 +3478,12 @@
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="goodsItemNumber" type="GoodsItemNumberContentType">
+      <xs:element name="goodsItemNumber" type="GoodsItemNumberContentType02">
         <xs:annotation>
           <xs:documentation>
             <description value="Goods item number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -3553,13 +3532,12 @@
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="goodsItemNumber" type="GoodsItemNumberContentType">
+      <xs:element name="goodsItemNumber" type="GoodsItemNumberContentType02">
         <xs:annotation>
           <xs:documentation>
             <description value="Goods item number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -3590,7 +3568,7 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
+            <xsdBaseType value="Alpha_2" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -3601,7 +3579,6 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -3704,13 +3681,12 @@
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="goodsItemNumber" type="GoodsItemNumberContentType">
+      <xs:element name="goodsItemNumber" type="GoodsItemNumberContentType02">
         <xs:annotation>
           <xs:documentation>
             <description value="Goods item number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -3741,7 +3717,6 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -3818,13 +3793,12 @@
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="goodsItemNumber" type="GoodsItemNumberContentType">
+      <xs:element name="goodsItemNumber" type="GoodsItemNumberContentType02">
         <xs:annotation>
           <xs:documentation>
             <description value="Goods item number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -3887,7 +3861,7 @@
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="goodsItemNumber" type="GoodsItemNumberContentType">
+      <xs:element name="goodsItemNumber" type="GoodsItemNumberContentType01">
         <xs:annotation>
           <xs:documentation>
             <description value="Goods item number" />
@@ -3924,13 +3898,12 @@
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="goodsItemNumber" type="GoodsItemNumberContentType">
+      <xs:element name="goodsItemNumber" type="GoodsItemNumberContentType02">
         <xs:annotation>
           <xs:documentation>
             <description value="Goods item number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -3951,7 +3924,7 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
+            <xsdBaseType value="Alpha_2" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -3962,7 +3935,6 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -4057,13 +4029,12 @@
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="goodsItemNumber" type="GoodsItemNumberContentType">
+      <xs:element name="goodsItemNumber" type="GoodsItemNumberContentType02">
         <xs:annotation>
           <xs:documentation>
             <description value="Goods item number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -4136,13 +4107,12 @@
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="goodsItemNumber" type="GoodsItemNumberContentType">
+      <xs:element name="goodsItemNumber" type="GoodsItemNumberContentType02">
         <xs:annotation>
           <xs:documentation>
             <description value="Goods item number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -4173,7 +4143,7 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
+            <xsdBaseType value="Alpha_2" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -4184,7 +4154,6 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -4293,7 +4262,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -4314,13 +4282,12 @@
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="goodsItemNumber" type="GoodsItemNumberContentType">
+      <xs:element name="goodsItemNumber" type="GoodsItemNumberContentType02">
         <xs:annotation>
           <xs:documentation>
             <description value="Goods item number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -4351,7 +4318,7 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
+            <xsdBaseType value="Alpha_2" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -4362,7 +4329,6 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -4465,13 +4431,12 @@
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="goodsItemNumber" type="GoodsItemNumberContentType">
+      <xs:element name="goodsItemNumber" type="GoodsItemNumberContentType02">
         <xs:annotation>
           <xs:documentation>
             <description value="Goods item number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -4495,17 +4460,6 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="countryOfDispatch" minOccurs="0" type="CountryOfDispatchContentType">
-        <xs:annotation>
-          <xs:documentation>
-            <description value="Country of dispatch" />
-            <codeList code="CL008" type="business" name="CountryCodesFullList" />
-            <format value="a2" />
-            <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
       <xs:element name="countryOfDestination" minOccurs="0" type="CountryOfDestinationContentType">
         <xs:annotation>
           <xs:documentation>
@@ -4513,7 +4467,6 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -4651,7 +4604,7 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
+            <xsdBaseType value="Alpha_2" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -4662,7 +4615,6 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -4844,7 +4796,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="HouseConsignment" minOccurs="0" maxOccurs="1999" type="HouseConsignmentType01">
+      <xs:element name="HouseConsignment" minOccurs="0" maxOccurs="99" type="HouseConsignmentType01">
         <xs:annotation>
           <xs:documentation>
             <description value="HOUSE CONSIGNMENT" />
@@ -4861,7 +4813,7 @@
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="HouseConsignment" maxOccurs="1999" type="HouseConsignmentType02">
+      <xs:element name="HouseConsignment" maxOccurs="99" type="HouseConsignmentType02">
         <xs:annotation>
           <xs:documentation>
             <description value="HOUSE CONSIGNMENT" />
@@ -4885,7 +4837,7 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
+            <xsdBaseType value="Alpha_2" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -4896,7 +4848,6 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -5022,11 +4973,11 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="PlaceOfLoading" type="PlaceOfLoadingType02">
+      <xs:element name="PlaceOfLoading" minOccurs="0" type="PlaceOfLoadingType02"> <!--##Added minOccurs="0" as this is optional (IE029 Only)##-->
         <xs:annotation>
           <xs:documentation>
             <description value="PLACE OF LOADING" />
-            <optionality value="R" />
+            <optionality value="O" />  <!--##Changed to Optional (IE029 Only)##-->
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -5086,7 +5037,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="HouseConsignment" maxOccurs="1999" type="HouseConsignmentType03">
+      <xs:element name="HouseConsignment" maxOccurs="99" type="HouseConsignmentType03">
         <xs:annotation>
           <xs:documentation>
             <description value="HOUSE CONSIGNMENT" />
@@ -5110,7 +5061,6 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -5224,7 +5174,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="HouseConsignment" maxOccurs="1999" type="HouseConsignmentType04">
+      <xs:element name="HouseConsignment" maxOccurs="99" type="HouseConsignmentType04">
         <xs:annotation>
           <xs:documentation>
             <description value="HOUSE CONSIGNMENT" />
@@ -5291,7 +5241,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="HouseConsignment" minOccurs="0" maxOccurs="1999" type="HouseConsignmentType05">
+      <xs:element name="HouseConsignment" minOccurs="0" maxOccurs="99" type="HouseConsignmentType05">
         <xs:annotation>
           <xs:documentation>
             <description value="HOUSE CONSIGNMENT" />
@@ -5395,7 +5345,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="HouseConsignment" maxOccurs="1999" type="HouseConsignmentType06">
+      <xs:element name="HouseConsignment" maxOccurs="99" type="HouseConsignmentType06">
         <xs:annotation>
           <xs:documentation>
             <description value="HOUSE CONSIGNMENT" />
@@ -5444,7 +5394,7 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
+            <xsdBaseType value="Alpha_2" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -5455,7 +5405,6 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -5637,7 +5586,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="HouseConsignment" maxOccurs="1999" type="HouseConsignmentType12">
+      <xs:element name="HouseConsignment" maxOccurs="99" type="HouseConsignmentType12">
         <xs:annotation>
           <xs:documentation>
             <description value="HOUSE CONSIGNMENT" />
@@ -5661,7 +5610,7 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
+            <xsdBaseType value="Alpha_2" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -5672,7 +5621,6 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -5862,7 +5810,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="HouseConsignment" maxOccurs="1999" type="HouseConsignmentType12">
+      <xs:element name="HouseConsignment" maxOccurs="99" type="HouseConsignmentType12">
         <xs:annotation>
           <xs:documentation>
             <description value="HOUSE CONSIGNMENT" />
@@ -5886,7 +5834,7 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
+            <xsdBaseType value="Alpha_2" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -5897,7 +5845,6 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -6124,7 +6071,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="HouseConsignment" minOccurs="0" maxOccurs="1999" type="HouseConsignmentType09">
+      <xs:element name="HouseConsignment" minOccurs="0" maxOccurs="99" type="HouseConsignmentType09">
         <xs:annotation>
           <xs:documentation>
             <description value="HOUSE CONSIGNMENT" />
@@ -6148,7 +6095,7 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
+            <xsdBaseType value="Alpha_2" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -6159,7 +6106,6 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -6349,7 +6295,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="HouseConsignment" maxOccurs="1999" type="HouseConsignmentType12">
+      <xs:element name="HouseConsignment" maxOccurs="99" type="HouseConsignmentType12">
         <xs:annotation>
           <xs:documentation>
             <description value="HOUSE CONSIGNMENT" />
@@ -6366,17 +6312,6 @@
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="countryOfDispatch" minOccurs="0" type="CountryOfDispatchContentType">
-        <xs:annotation>
-          <xs:documentation>
-            <description value="Country of dispatch" />
-            <codeList code="CL008" type="business" name="CountryCodesFullList" />
-            <format value="a2" />
-            <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
       <xs:element name="countryOfDestination" minOccurs="0" type="CountryOfDestinationContentType">
         <xs:annotation>
           <xs:documentation>
@@ -6384,7 +6319,6 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -6566,7 +6500,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="HouseConsignment" maxOccurs="1999" type="HouseConsignmentType13">
+      <xs:element name="HouseConsignment" maxOccurs="99" type="HouseConsignmentType13">
         <xs:annotation>
           <xs:documentation>
             <description value="HOUSE CONSIGNMENT" />
@@ -6583,17 +6517,6 @@
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="countryOfDispatch" minOccurs="0" type="CountryOfDispatchContentType">
-        <xs:annotation>
-          <xs:documentation>
-            <description value="Country of dispatch" />
-            <codeList code="CL008" type="business" name="CountryCodesFullList" />
-            <format value="a2" />
-            <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
       <xs:element name="countryOfDestination" minOccurs="0" type="CountryOfDestinationContentType">
         <xs:annotation>
           <xs:documentation>
@@ -6601,7 +6524,6 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -6791,7 +6713,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="HouseConsignment" maxOccurs="1999" type="HouseConsignmentType13">
+      <xs:element name="HouseConsignment" maxOccurs="99" type="HouseConsignmentType13">
         <xs:annotation>
           <xs:documentation>
             <description value="HOUSE CONSIGNMENT" />
@@ -6825,17 +6747,6 @@
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="countryOfDispatch" minOccurs="0" type="CountryOfDispatchContentType">
-        <xs:annotation>
-          <xs:documentation>
-            <description value="Country of dispatch" />
-            <codeList code="CL008" type="business" name="CountryCodesFullList" />
-            <format value="a2" />
-            <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
       <xs:element name="countryOfDestination" minOccurs="0" type="CountryOfDestinationContentType">
         <xs:annotation>
           <xs:documentation>
@@ -6843,7 +6754,6 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -7025,7 +6935,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="HouseConsignment" maxOccurs="1999" type="HouseConsignmentType13">
+      <xs:element name="HouseConsignment" maxOccurs="99" type="HouseConsignmentType13">
         <xs:annotation>
           <xs:documentation>
             <description value="HOUSE CONSIGNMENT" />
@@ -7042,17 +6952,6 @@
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="countryOfDispatch" minOccurs="0" type="CountryOfDispatchContentType">
-        <xs:annotation>
-          <xs:documentation>
-            <description value="Country of dispatch" />
-            <codeList code="CL008" type="business" name="CountryCodesFullList" />
-            <format value="a2" />
-            <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
       <xs:element name="countryOfDestination" minOccurs="0" type="CountryOfDestinationContentType">
         <xs:annotation>
           <xs:documentation>
@@ -7060,7 +6959,6 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -7238,7 +7136,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="TRANSPORT CHARGES" />
-            <optionality value="D" />
+            <optionality value="O" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -7250,7 +7148,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="HouseConsignment" maxOccurs="1999" type="HouseConsignmentType13">
+      <xs:element name="HouseConsignment" maxOccurs="99" type="HouseConsignmentType13">
         <xs:annotation>
           <xs:documentation>
             <description value="HOUSE CONSIGNMENT" />
@@ -7274,7 +7172,7 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
+            <xsdBaseType value="Alpha_2" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -7285,7 +7183,6 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -7475,7 +7372,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="HouseConsignment" maxOccurs="1999" type="HouseConsignmentType10">
+      <xs:element name="HouseConsignment" maxOccurs="99" type="HouseConsignmentType10">
         <xs:annotation>
           <xs:documentation>
             <description value="HOUSE CONSIGNMENT" />
@@ -7492,7 +7389,7 @@
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="HouseConsignment" maxOccurs="1999" type="HouseConsignmentType11">
+      <xs:element name="HouseConsignment" maxOccurs="99" type="HouseConsignmentType11">
         <xs:annotation>
           <xs:documentation>
             <description value="HOUSE CONSIGNMENT" />
@@ -7903,7 +7800,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Warning code" />
-            <codeList code="CL903" type="business" name="WarningCode" />
+            <codeList code="CL903" type="business" name="Warningcode" />
             <format value="an6" />
             <optionality value="R" />
           </xs:documentation>
@@ -8277,7 +8174,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Code" />
-            <codeList code="CL243" type="business" name="XFTControlResultCodeDestination" />
+            <codeList code="CL243" type="business" name="XftControlResultCodeDestination" />
             <format value="an2" />
             <optionality value="R" />
           </xs:documentation>
@@ -8477,7 +8374,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -8510,7 +8406,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -8540,7 +8435,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -8573,7 +8467,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -8925,7 +8818,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -8978,7 +8870,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -9008,7 +8899,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -9038,7 +8928,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -9160,7 +9049,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -9490,7 +9378,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -9543,7 +9430,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -9583,7 +9469,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -9623,7 +9508,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -9653,7 +9537,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -9762,7 +9645,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -9791,7 +9673,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -9823,7 +9704,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -9831,7 +9711,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Type of identification" />
-            <codeList code="CL750" type="business" name="TypeOfIdentificationOfMeansOfTransport" />
+            <codeList code="CL750" type="business" name="ClTypeOfIdentificationOfMeansOfTransport" />
             <format value="n2" />
             <optionality value="O" />
           </xs:documentation>
@@ -9873,7 +9753,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -9881,7 +9760,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Type of identification" />
-            <codeList code="CL750" type="business" name="TypeOfIdentificationOfMeansOfTransport" />
+            <codeList code="CL750" type="business" name="ClTypeOfIdentificationOfMeansOfTransport" />
             <format value="n2" />
             <optionality value="R" />
           </xs:documentation>
@@ -9923,7 +9802,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -9931,7 +9809,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Type of identification" />
-            <codeList code="CL750" type="business" name="TypeOfIdentificationOfMeansOfTransport" />
+            <codeList code="CL750" type="business" name="ClTypeOfIdentificationOfMeansOfTransport" />
             <format value="n2" />
             <optionality value="O" />
           </xs:documentation>
@@ -9973,7 +9851,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -9981,7 +9858,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Type of identification" />
-            <codeList code="CL750" type="business" name="TypeOfIdentificationOfMeansOfTransport" />
+            <codeList code="CL750" type="business" name="ClTypeOfIdentificationOfMeansOfTransport" />
             <format value="n2" />
             <optionality value="O" />
           </xs:documentation>
@@ -10023,7 +9900,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -10031,7 +9907,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Type of identification" />
-            <codeList code="CL750" type="business" name="TypeOfIdentificationOfMeansOfTransport" />
+            <codeList code="CL750" type="business" name="ClTypeOfIdentificationOfMeansOfTransport" />
             <format value="n2" />
             <optionality value="R" />
           </xs:documentation>
@@ -10073,7 +9949,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -10081,7 +9956,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Type of identification" />
-            <codeList code="CL750" type="business" name="TypeOfIdentificationOfMeansOfTransport" />
+            <codeList code="CL750" type="business" name="ClTypeOfIdentificationOfMeansOfTransport" />
             <format value="n2" />
             <optionality value="O" />
           </xs:documentation>
@@ -10570,7 +10445,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -10599,7 +10473,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -10657,7 +10530,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -10694,7 +10566,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -10838,7 +10709,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -11277,7 +11147,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -11306,7 +11175,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -11400,7 +11268,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -11459,7 +11326,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -11558,7 +11424,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -11617,7 +11482,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -11713,7 +11577,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -11766,7 +11629,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -11890,7 +11752,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -11927,7 +11788,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -12054,7 +11914,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -12225,7 +12084,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -12262,7 +12120,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -12315,7 +12172,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -12355,7 +12211,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -12403,7 +12258,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -12451,7 +12305,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -12499,7 +12352,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -12507,7 +12359,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Guarantee type" />
-            <codeList code="CL286" type="business" name="GuaranteeTypeWithGRN" />
+            <codeList code="CL286" type="business" name="GuaranteeTypeWithGrn" />
             <format value="an1" />
             <optionality value="R" />
             <xsdBaseType value="AlphanumericCapital1Type" />
@@ -12537,7 +12389,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -12575,7 +12426,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -12583,7 +12433,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Guarantee type" />
-            <codeList code="CL286" type="business" name="GuaranteeTypeWithGRN" />
+            <codeList code="CL286" type="business" name="GuaranteeTypeWithGrn" />
             <format value="an1" />
             <optionality value="R" />
             <xsdBaseType value="AlphanumericCapital1Type" />
@@ -12613,7 +12463,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -12621,7 +12470,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Guarantee type" />
-            <codeList code="CL286" type="business" name="GuaranteeTypeWithGRN" />
+            <codeList code="CL286" type="business" name="GuaranteeTypeWithGrn" />
             <format value="an1" />
             <optionality value="R" />
             <xsdBaseType value="AlphanumericCapital1Type" />
@@ -12680,12 +12529,12 @@
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="identificationNumber" minOccurs="0" type="IdentificationNumberContentType04">
+      <xs:element name="identificationNumber" type="IdentificationNumberContentType04">
         <xs:annotation>
           <xs:documentation>
             <description value="Identification number" />
             <format value="an..17" />
-            <optionality value="O" />
+            <optionality value="R" />
             <xsdBaseType value="Alphanumeric_Max17" />
           </xs:documentation>
         </xs:annotation>
@@ -12898,12 +12747,12 @@
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="identificationNumber" minOccurs="0" type="IdentificationNumberContentType04">
+      <xs:element name="identificationNumber" type="IdentificationNumberContentType04">
         <xs:annotation>
           <xs:documentation>
             <description value="Identification number" />
             <format value="an..17" />
-            <optionality value="O" />
+            <optionality value="R" />
             <xsdBaseType value="Alphanumeric_Max17" />
           </xs:documentation>
         </xs:annotation>
@@ -13977,7 +13826,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -13988,18 +13836,7 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="countryOfDestination" minOccurs="0" type="CountryOfDestinationContentType">
-        <xs:annotation>
-          <xs:documentation>
-            <description value="Country of destination" />
-            <codeList code="CL008" type="business" name="CountryCodesFullList" />
-            <format value="a2" />
-            <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
+            <xsdBaseType value="Alpha_2" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -14136,7 +13973,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -14173,7 +14009,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -14184,18 +14019,7 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="countryOfDestination" minOccurs="0" type="CountryOfDestinationContentType">
-        <xs:annotation>
-          <xs:documentation>
-            <description value="Country of destination" />
-            <codeList code="CL008" type="business" name="CountryCodesFullList" />
-            <format value="a2" />
-            <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
+            <xsdBaseType value="Alpha_2" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -14336,6 +14160,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
+      <!-- Manually added country of destination so we don't need to disable/enable all code related to this when we switch to RFC39 -->
       <xs:element name="countryOfDestination" minOccurs="0" type="CountryOfDestinationContentType">
         <xs:annotation>
           <xs:documentation>
@@ -14454,17 +14279,16 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="grossMass" minOccurs="0" type="GrossMassContentType02">
+      <xs:element name="grossMass" minOccurs="0" type="GrossMassContentType01">
         <xs:annotation>
           <xs:documentation>
             <description value="Gross mass" />
             <format value="n..16,6" />
             <optionality value="O" />
-            <xsdBaseType value="DecimalWithZero_16_6" />
+            <xsdBaseType value="DecimalWithoutZero_16_6" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -14523,7 +14347,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -14567,7 +14390,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -14578,7 +14400,7 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
+            <xsdBaseType value="Alpha_2" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -14697,17 +14519,16 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="grossMass" minOccurs="0" type="GrossMassContentType02">
+      <xs:element name="grossMass" minOccurs="0" type="GrossMassContentType01">
         <xs:annotation>
           <xs:documentation>
             <description value="Gross mass" />
             <format value="n..16,6" />
             <optionality value="O" />
-            <xsdBaseType value="DecimalWithZero_16_6" />
+            <xsdBaseType value="DecimalWithoutZero_16_6" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -14776,7 +14597,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -14787,18 +14607,7 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="countryOfDestination" minOccurs="0" type="CountryOfDestinationContentType">
-        <xs:annotation>
-          <xs:documentation>
-            <description value="Country of destination" />
-            <codeList code="CL008" type="business" name="CountryCodesFullList" />
-            <format value="a2" />
-            <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
+            <xsdBaseType value="Alpha_2" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -14925,7 +14734,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -14952,7 +14760,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -14963,18 +14770,7 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="countryOfDestination" minOccurs="0" type="CountryOfDestinationContentType">
-        <xs:annotation>
-          <xs:documentation>
-            <description value="Country of destination" />
-            <codeList code="CL008" type="business" name="CountryCodesFullList" />
-            <format value="a2" />
-            <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
+            <xsdBaseType value="Alpha_2" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -15111,29 +14907,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="countryOfDispatch" minOccurs="0" type="CountryOfDispatchContentType">
-        <xs:annotation>
-          <xs:documentation>
-            <description value="Country of dispatch" />
-            <codeList code="CL008" type="business" name="CountryCodesFullList" />
-            <format value="a2" />
-            <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="countryOfDestination" minOccurs="0" type="CountryOfDestinationContentType">
-        <xs:annotation>
-          <xs:documentation>
-            <description value="Country of destination" />
-            <codeList code="CL008" type="business" name="CountryCodesFullList" />
-            <format value="a2" />
-            <optionality value="D" />
-            <xsdBaseType value="CountryCodeType" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -15273,7 +15046,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -15344,7 +15116,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -15415,7 +15186,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -15486,7 +15256,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -15680,7 +15449,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -15688,7 +15456,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Code" />
-            <codeList code="CL252" type="business" name="InvalidGuaranteeReason" />
+            <codeList code="CL252" type="business" name="GuaranteeTypeWithGrn" />
             <format value="an..3" />
             <optionality value="R" />
           </xs:documentation>
@@ -15719,7 +15487,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -15727,7 +15494,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Code" />
-            <codeList code="CL252" type="business" name="InvalidGuaranteeReason" />
+            <codeList code="CL252" type="business" name="GuaranteeTypeWithGrn" />
             <format value="an..3" />
             <optionality value="R" />
           </xs:documentation>
@@ -15929,7 +15696,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="UN LOCODE" />
-            <codeList code="CL244" type="business" name="UnLocodeExtended" />
+            <codeList code="CL244" type="business" name="UnlocodeExtended" />
             <format value="an..17" />
             <optionality value="D" />
           </xs:documentation>
@@ -16036,7 +15803,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="UN LOCODE" />
-            <codeList code="CL244" type="business" name="UnLocodeExtended" />
+            <codeList code="CL244" type="business" name="UnlocodeExtended" />
             <format value="an..17" />
             <optionality value="D" />
           </xs:documentation>
@@ -16143,7 +15910,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="UN LOCODE" />
-            <codeList code="CL244" type="business" name="UnLocodeExtended" />
+            <codeList code="CL244" type="business" name="UnlocodeExtended" />
             <format value="an..17" />
             <optionality value="D" />
           </xs:documentation>
@@ -16250,7 +16017,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="UN LOCODE" />
-            <codeList code="CL244" type="business" name="UnLocodeExtended" />
+            <codeList code="CL244" type="business" name="UnlocodeExtended" />
             <format value="an..17" />
             <optionality value="D" />
           </xs:documentation>
@@ -16357,7 +16124,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="UN LOCODE" />
-            <codeList code="CL244" type="business" name="UnLocodeExtended" />
+            <codeList code="CL244" type="business" name="UnlocodeExtended" />
             <format value="an..17" />
             <optionality value="D" />
           </xs:documentation>
@@ -16437,7 +16204,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="UN LOCODE" />
-            <codeList code="CL244" type="business" name="UnLocodeExtended" />
+            <codeList code="CL244" type="business" name="UnlocodeExtended" />
             <format value="an..17" />
             <optionality value="D" />
           </xs:documentation>
@@ -16493,7 +16260,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="UN LOCODE" />
-            <codeList code="CL244" type="business" name="UnLocodeExtended" />
+            <codeList code="CL244" type="business" name="UnlocodeExtended" />
             <format value="an..17" />
             <optionality value="D" />
           </xs:documentation>
@@ -16603,7 +16370,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -16652,7 +16418,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -16701,7 +16466,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -16750,7 +16514,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -16800,7 +16563,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="UN LOCODE" />
-            <codeList code="CL244" type="business" name="UnLocodeExtended" />
+            <codeList code="CL244" type="business" name="UnlocodeExtended" />
             <format value="an..17" />
             <optionality value="O" />
           </xs:documentation>
@@ -16840,7 +16603,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="UN LOCODE" />
-            <codeList code="CL244" type="business" name="UnLocodeExtended" />
+            <codeList code="CL244" type="business" name="UnlocodeExtended" />
             <format value="an..17" />
             <optionality value="O" />
           </xs:documentation>
@@ -16880,7 +16643,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="UN LOCODE" />
-            <codeList code="CL244" type="business" name="UnLocodeExtended" />
+            <codeList code="CL244" type="business" name="UnlocodeExtended" />
             <format value="an..17" />
             <optionality value="O" />
           </xs:documentation>
@@ -16920,7 +16683,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="UN LOCODE" />
-            <codeList code="CL244" type="business" name="UnLocodeExtended" />
+            <codeList code="CL244" type="business" name="UnlocodeExtended" />
             <format value="an..17" />
             <optionality value="O" />
           </xs:documentation>
@@ -16963,7 +16726,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="UN LOCODE" />
-            <codeList code="CL244" type="business" name="UnLocodeExtended" />
+            <codeList code="CL244" type="business" name="UnlocodeExtended" />
             <format value="an..17" />
             <optionality value="O" />
           </xs:documentation>
@@ -17003,7 +16766,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="UN LOCODE" />
-            <codeList code="CL244" type="business" name="UnLocodeExtended" />
+            <codeList code="CL244" type="business" name="UnlocodeExtended" />
             <format value="an..17" />
             <optionality value="O" />
           </xs:documentation>
@@ -17131,7 +16894,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -17155,7 +16917,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="goodsItemNumber" minOccurs="0" type="GoodsItemNumberContentType">
+      <xs:element name="goodsItemNumber" minOccurs="0" type="GoodsItemNumberContentType01">
         <xs:annotation>
           <xs:documentation>
             <description value="Goods item number" />
@@ -17200,7 +16962,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -17259,7 +17020,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -17283,7 +17043,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="goodsItemNumber" minOccurs="0" type="GoodsItemNumberContentType">
+      <xs:element name="goodsItemNumber" minOccurs="0" type="GoodsItemNumberContentType01">
         <xs:annotation>
           <xs:documentation>
             <description value="Goods item number" />
@@ -17358,7 +17118,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -17382,13 +17141,12 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="goodsItemNumber" minOccurs="0" type="GoodsItemNumberContentType">
+      <xs:element name="goodsItemNumber" minOccurs="0" type="GoodsItemNumberContentType02">
         <xs:annotation>
           <xs:documentation>
             <description value="Goods item number" />
             <format value="n..5" />
             <optionality value="O" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -17446,7 +17204,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -17495,7 +17252,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -17544,7 +17300,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -17568,7 +17323,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="goodsItemNumber" minOccurs="0" type="GoodsItemNumberContentType">
+      <xs:element name="goodsItemNumber" minOccurs="0" type="GoodsItemNumberContentType01">
         <xs:annotation>
           <xs:documentation>
             <description value="Goods item number" />
@@ -17643,7 +17398,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -17692,7 +17446,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -17741,7 +17494,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -17765,7 +17517,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="goodsItemNumber" minOccurs="0" type="GoodsItemNumberContentType">
+      <xs:element name="goodsItemNumber" minOccurs="0" type="GoodsItemNumberContentType01">
         <xs:annotation>
           <xs:documentation>
             <description value="Goods item number" />
@@ -18125,7 +17877,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -18166,7 +17917,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -18269,7 +18019,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -18341,7 +18090,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -18393,7 +18141,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -18433,7 +18180,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -18462,7 +18208,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -18491,7 +18236,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -18520,7 +18264,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -18549,7 +18292,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -18632,7 +18374,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -18643,7 +18384,6 @@
             <codeList code="CL008" type="business" name="CountryCodesFullList" />
             <format value="a2" />
             <optionality value="O" />
-            <xsdBaseType value="CountryCodeType" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -18675,7 +18415,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -18736,7 +18475,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -18795,7 +18533,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -18844,7 +18581,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -18893,7 +18629,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -18942,7 +18677,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -19001,7 +18735,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -19063,7 +18796,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -20303,7 +20035,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Business rejection type" />
-            <codeList code="CL560" type="business" name="BusinessRejectionTypeDepExp" />
+            <codeList code="CL560" type="business" name="BusinessRejectiontTypeDepExp" />
             <format value="an3" />
             <optionality value="R" />
           </xs:documentation>
@@ -20794,7 +20526,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Declaration type" />
-            <codeList code="CL189" type="business" name="TypeOfDeclarationTIR" />
+            <codeList code="CL189" type="business" name="TypeOfDeclarationTir" />
             <format value="an..5" />
             <optionality value="R" />
           </xs:documentation>
@@ -21099,7 +20831,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Declaration type" />
-            <codeList code="CL188" type="business" name="TypeOfTransitDeclarationNonTIR" />
+            <codeList code="CL188" type="business" name="TypeOfTransitDeclarationNonTir" />
             <format value="an..5" />
             <optionality value="R" />
           </xs:documentation>
@@ -21314,7 +21046,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Declaration type" />
-            <codeList code="CL188" type="business" name="TypeOfTransitDeclarationNonTIR" />
+            <codeList code="CL188" type="business" name="TypeOfTransitDeclarationNonTir" />
             <format value="an..5" />
             <optionality value="D" />
           </xs:documentation>
@@ -21413,7 +21145,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Declaration type" />
-            <codeList code="CL188" type="business" name="TypeOfTransitDeclarationNonTIR" />
+            <codeList code="CL188" type="business" name="TypeOfTransitDeclarationNonTir" />
             <format value="an..5" />
             <optionality value="R" />
           </xs:documentation>
@@ -21443,7 +21175,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Security" />
-            <codeList code="CL223" type="business" name="DeclarationTypeSecurityEXS" />
+            <codeList code="CL223" type="business" name="DeclarationTypeSecurityExs" />
             <format value="n1" />
             <optionality value="R" />
           </xs:documentation>
@@ -21502,7 +21234,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Declaration type" />
-            <codeList code="CL188" type="business" name="TypeOfTransitDeclarationNonTIR" />
+            <codeList code="CL188" type="business" name="TypeOfTransitDeclarationNonTir" />
             <format value="an..5" />
             <optionality value="D" />
           </xs:documentation>
@@ -21532,7 +21264,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Security" />
-            <codeList code="CL223" type="business" name="DeclarationTypeSecurityEXS" />
+            <codeList code="CL223" type="business" name="DeclarationTypeSecurityExs" />
             <format value="n1" />
             <optionality value="D" />
           </xs:documentation>
@@ -21572,7 +21304,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Request rejection reason code" />
-            <codeList code="CL224" type="business" name="AxrRejectionReason" />
+            <codeList code="CL224" type="business" name="Axrrejectionreason" />
             <format value="n..2" />
             <optionality value="O" />
           </xs:documentation>
@@ -21784,7 +21516,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="AES communication purpose" />
-            <codeList code="CL158" type="business" name="XFTCommunicationPurpose" />
+            <codeList code="CL158" type="business" name="XftCommunicationPurpose" />
             <format value="n1" />
             <optionality value="R" />
           </xs:documentation>
@@ -21889,7 +21621,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -21928,7 +21659,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -21967,7 +21697,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -22006,7 +21735,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -22048,7 +21776,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -22103,7 +21830,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -22158,7 +21884,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -22213,7 +21938,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -22268,7 +21992,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -22323,7 +22046,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -22378,7 +22100,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -22434,7 +22155,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Type of identification" />
-            <codeList code="CL750" type="business" name="TypeOfIdentificationOfMeansOfTransport" />
+            <codeList code="CL750" type="business" name="ClTypeOfIdentificationOfMeansOfTransport" />
             <format value="n2" />
             <optionality value="R" />
           </xs:documentation>
@@ -22474,7 +22195,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Type of identification" />
-            <codeList code="CL750" type="business" name="TypeOfIdentificationOfMeansOfTransport" />
+            <codeList code="CL750" type="business" name="ClTypeOfIdentificationOfMeansOfTransport" />
             <format value="n2" />
             <optionality value="R" />
           </xs:documentation>
@@ -22519,7 +22240,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -22527,7 +22247,7 @@
         <xs:annotation>
           <xs:documentation>
             <description value="Type" />
-            <codeList code="CL716" type="business" name="ControlType" />
+            <codeList code="CL716" type="business" name="ClControlRecommendationCode" />
             <format value="an..3" />
             <optionality value="R" />
             <xsdBaseType value="Alphanumeric_Max3" />
@@ -22562,7 +22282,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -22714,7 +22433,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -22796,7 +22514,6 @@
             <description value="Sequence number" />
             <format value="n..5" />
             <optionality value="R" />
-            <xsdBaseType value="NumericWithoutZero_5" />
           </xs:documentation>
         </xs:annotation>
       </xs:element>

--- a/conf/xsd/doc.xsd
+++ b/conf/xsd/doc.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ncts.dgtaxud.ec" xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" elementFormDefault="qualified" version="51.8.6" targetNamespace="http://ncts.dgtaxud.ec" attributeFormDefault="unqualified" vc:minVersion="1.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ncts.dgtaxud.ec" xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" elementFormDefault="qualified" version="51.8.0" targetNamespace="http://ncts.dgtaxud.ec" attributeFormDefault="unqualified" vc:minVersion="1.1">
   <!--=========================================-->
   <!--      DOCUMENTATION ELEMENTS             -->
   <!--=========================================-->

--- a/conf/xsd/htypes.xsd
+++ b/conf/xsd/htypes.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ncts.dgtaxud.ec" xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" elementFormDefault="unqualified" attributeFormDefault="unqualified" version="51.8.6" vc:minVersion="1.1" targetNamespace="http://ncts.dgtaxud.ec">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ncts.dgtaxud.ec" xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" elementFormDefault="unqualified" attributeFormDefault="unqualified" version="51.8.0" vc:minVersion="1.1" targetNamespace="http://ncts.dgtaxud.ec">
   <!--=======================================================-->
   <!--============= Message Header Definition  ==============-->
   <!--=======================================================-->
@@ -7,8 +7,10 @@
   <xs:include schemaLocation="tcl.xsd" />
   <xs:include schemaLocation="stypes.xsd" />
   <xs:group name="MESSAGE">
+  <!-- CTC Start: We don't accept a message sender from traders, we so create groups to -->
+  <!-- include and exclude the message sender -->
     <xs:annotation>
-      <xs:documentation>Used by all messages</xs:documentation>
+      <xs:documentation>Used by messages to the Trader</xs:documentation>
     </xs:annotation>
     <xs:sequence>
       <xs:element name="messageSender" type="MessageSenderContentType">
@@ -18,6 +20,33 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
+      <xs:group ref="MESSAGE_1" />
+      <!-- Include message type and correlation ID -->
+      <xs:group ref="MESSAGE_TYPE" />
+      <xs:group ref="CORRELATION_IDENTIFIER" />
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MESSAGE_FROM_TRADER">
+    <xs:annotation>
+      <xs:documentation>Used by messages from the Trader</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="messageSender" type="MessageSenderContentType" minOccurs="0" maxOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <description value="Message sender" />
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:group ref="MESSAGE_1" />
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MESSAGE_1">
+  <!-- CTC End -->
+    <xs:annotation>
+      <xs:documentation>Used by all messages</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
       <xs:element name="messageRecipient" type="MessageRecipientContentType">
         <xs:annotation>
           <xs:documentation>
@@ -39,6 +68,12 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
+      <!-- CTC Start - messageType and correlationIdentifier will be done elsewhere -->
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="MESSAGE_TYPE">
+    <xs:sequence>
+      <!-- CTC End -->
       <xs:element name="messageType" type="MessageTypes">
         <xs:annotation>
           <xs:documentation>
@@ -47,6 +82,12 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
+      <!-- CTC Start: continuation of splitting from above -->
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="CORRELATION_IDENTIFIER">
+    <xs:sequence>
+      <!-- CTC End -->
       <xs:element name="correlationIdentifier" type="CorrelationIdentifierContentType" minOccurs="0">
         <xs:annotation>
           <xs:documentation>
@@ -56,24 +97,24 @@
       </xs:element>
     </xs:sequence>
   </xs:group>
- <!--================================================================================--> 
- <!--===== MessageIdentification                                                           -->
- <!--================================================================================-->
+  <!--================================================================================-->
+  <!--===== MessageIdentification                                                     -->
+  <!--================================================================================-->
   <xs:simpleType name="MessageIdentificationContentType">
-      <xs:restriction base="xs:token">
+    <xs:restriction base="xs:token">
       <xs:pattern value=".{1,35}" />
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== MessageRecipient                                                                -->
+  <!--===== MessageRecipient                                                          -->
   <!--================================================================================-->
   <xs:simpleType name="MessageRecipientContentType">
-      <xs:restriction base="xs:token">
+    <xs:restriction base="xs:token">
       <xs:pattern value=".{1,35}" />
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== MessageSender                                                                   -->
+  <!--===== MessageSender                                                             -->
   <!--================================================================================-->
   <xs:simpleType name="MessageSenderContentType">
     <xs:restriction base="xs:token">
@@ -81,7 +122,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== CorrelationIdentifier                                                           -->
+  <!--===== CorrelationIdentifier                                                     -->
   <!--================================================================================-->
   <xs:simpleType name="CorrelationIdentifierContentType">
     <xs:restriction base="xs:token">
@@ -89,7 +130,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== PreparationDateAndTime                                                          -->
+  <!--===== PreparationDateAndTime                                                    -->
   <!--================================================================================-->
   <xs:simpleType name="PreparationDateAndTimeContentType">
     <xs:restriction base="xs:dateTime">

--- a/conf/xsd/stypes.xsd
+++ b/conf/xsd/stypes.xsd
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ncts.dgtaxud.ec" xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" targetNamespace="http://ncts.dgtaxud.ec" elementFormDefault="unqualified" attributeFormDefault="unqualified" version="51.8.6" vc:minVersion="1.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ncts.dgtaxud.ec" xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" targetNamespace="http://ncts.dgtaxud.ec" elementFormDefault="unqualified" attributeFormDefault="unqualified" version="51.8.0" vc:minVersion="1.1">
   <!--================================================================================-->
-  <!--===== Simple Types                                                                    -->
-  <!--===== DDNTA 5.15.2                                                                    -->
-  <!--===== NCTS P5 Phase Definition                                                        -->
-  <!--===== XSD version 51.8.6                                                              -->
-  <!--===== Aligned with RFC-List version DDNTA RFC-List.39                                 -->
-  <!--================================================================================-->
-  <!--================================================================================-->
-  <!--===== Data Item Types                                                                 -->
+  <!--===== Simple Types                                                              -->
+  <!--===== DDNTA 5.15.0                                                              -->
+  <!--===== NCTS P5 Phase Definition                                                  -->
+  <!--===== XSD version 51.8.0                                                        -->
+  <!--===== Aligned with RFC-List version DDNTA RFC-List.36                           -->
   <!--================================================================================-->
   <!--================================================================================-->
-  <!--===== AcceptanceDateAndTime                                                           -->
+  <!--===== Data Item Types                                                           -->
+  <!--================================================================================-->
+  <!--================================================================================-->
+  <!--===== AcceptanceDateAndTime                                                     -->
   <!--================================================================================-->
   <xs:simpleType name="AcceptanceDateAndTimeContentType">
     <xs:annotation>
@@ -22,7 +22,7 @@
     <xs:restriction base="DateTimeType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AccessCode                                                                      -->
+  <!--===== AccessCode                                                                -->
   <!--================================================================================-->
   <xs:simpleType name="AccessCodeContentType01">
     <xs:annotation>
@@ -41,7 +41,7 @@
     <xs:restriction base="AlphaNumeric_4_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AccessCodeCurrent                                                               -->
+  <!--===== AccessCodeCurrent                                                         -->
   <!--================================================================================-->
   <xs:simpleType name="AccessCodeCurrentContentType">
     <xs:annotation>
@@ -52,7 +52,7 @@
     <xs:restriction base="AlphaNumeric_MAX4_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AccessCodeNew                                                                   -->
+  <!--===== AccessCodeNew                                                             -->
   <!--================================================================================-->
   <xs:simpleType name="AccessCodeNewContentType">
     <xs:annotation>
@@ -63,7 +63,7 @@
     <xs:restriction base="AlphaNumeric_MAX4_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AdditionalDeclarationType                                                       -->
+  <!--===== AdditionalDeclarationType                                                 -->
   <!--================================================================================-->
   <xs:simpleType name="AdditionalDeclarationTypeContentType">
     <xs:annotation>
@@ -76,7 +76,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AdditionalIdentifier                                                            -->
+  <!--===== AdditionalIdentifier                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="AdditionalIdentifierContentType01">
     <xs:annotation>
@@ -95,7 +95,7 @@
     <xs:restriction base="AlphaNumeric_MAX4_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AESCommunicationPurpose                                                         -->
+  <!--===== AESCommunicationPurpose                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="AESCommunicationPurposeContentType">
     <xs:annotation>
@@ -108,7 +108,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AmendmentAcceptanceDateAndTime                                                  -->
+  <!--===== AmendmentAcceptanceDateAndTime                                            -->
   <!--================================================================================-->
   <xs:simpleType name="AmendmentAcceptanceDateAndTimeContentType">
     <xs:annotation>
@@ -119,7 +119,7 @@
     <xs:restriction base="DateTimeType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AmendmentNotificationDateAndTime                                                -->
+  <!--===== AmendmentNotificationDateAndTime                                          -->
   <!--================================================================================-->
   <xs:simpleType name="AmendmentNotificationDateAndTimeContentType">
     <xs:annotation>
@@ -130,7 +130,7 @@
     <xs:restriction base="DateTimeType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AmendmentSubmissionDateAndTime                                                  -->
+  <!--===== AmendmentSubmissionDateAndTime                                            -->
   <!--================================================================================-->
   <xs:simpleType name="AmendmentSubmissionDateAndTimeContentType">
     <xs:annotation>
@@ -141,7 +141,7 @@
     <xs:restriction base="DateTimeType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AmendmentTypeFlag                                                               -->
+  <!--===== AmendmentTypeFlag                                                         -->
   <!--================================================================================-->
   <xs:simpleType name="AmendmentTypeFlagContentType">
     <xs:annotation>
@@ -154,7 +154,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AmountClaimed                                                                   -->
+  <!--===== AmountClaimed                                                             -->
   <!--================================================================================-->
   <xs:simpleType name="AmountClaimedContentType">
     <xs:annotation>
@@ -165,7 +165,7 @@
     <xs:restriction base="DecimalWithZero_16_2" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AmountConcerned                                                                 -->
+  <!--===== AmountConcerned                                                           -->
   <!--================================================================================-->
   <xs:simpleType name="AmountConcernedContentType">
     <xs:annotation>
@@ -176,7 +176,7 @@
     <xs:restriction base="DecimalWithZero_16_2" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AmountToBeCovered                                                               -->
+  <!--===== AmountToBeCovered                                                         -->
   <!--================================================================================-->
   <xs:simpleType name="AmountToBeCoveredContentType">
     <xs:annotation>
@@ -187,7 +187,7 @@
     <xs:restriction base="DecimalWithZero_16_2" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ArrivalDateAndTimeActual                                                        -->
+  <!--===== ArrivalDateAndTimeActual                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="ArrivalDateAndTimeActualContentType">
     <xs:annotation>
@@ -198,7 +198,7 @@
     <xs:restriction base="DateTimeType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ArrivalDateAndTime                                                              -->
+  <!--===== ArrivalDateAndTime                                                        -->
   <!--================================================================================-->
   <xs:simpleType name="ArrivalDateAndTimeContentType">
     <xs:annotation>
@@ -209,7 +209,7 @@
     <xs:restriction base="DateTimeType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ArrivalDateAndTimeEstimated                                                     -->
+  <!--===== ArrivalDateAndTimeEstimated                                               -->
   <!--================================================================================-->
   <xs:simpleType name="ArrivalDateAndTimeEstimatedContentType">
     <xs:annotation>
@@ -220,7 +220,7 @@
     <xs:restriction base="DateTimeType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ArrivalNotificationDateAndTime                                                  -->
+  <!--===== ArrivalNotificationDateAndTime                                            -->
   <!--================================================================================-->
   <xs:simpleType name="ArrivalNotificationDateAndTimeContentType">
     <xs:annotation>
@@ -231,7 +231,7 @@
     <xs:restriction base="DateTimeType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AuthorisationNumber                                                             -->
+  <!--===== AuthorisationNumber                                                       -->
   <!--================================================================================-->
   <xs:simpleType name="AuthorisationNumberContentType01">
     <xs:annotation>
@@ -250,7 +250,7 @@
     <xs:restriction base="AlphaNumeric_MAX35_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Authority                                                                       -->
+  <!--===== Authority                                                                 -->
   <!--================================================================================-->
   <xs:simpleType name="AuthorityContentType01">
     <xs:annotation>
@@ -269,7 +269,7 @@
     <xs:restriction base="Alphanumeric_Max35" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Balance                                                                         -->
+  <!--===== Balance                                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="BalanceContentType">
     <xs:annotation>
@@ -280,7 +280,7 @@
     <xs:restriction base="DecimalWithZero_16_2" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== BindingItinerary                                                                -->
+  <!--===== BindingItinerary                                                          -->
   <!--================================================================================-->
   <xs:simpleType name="BindingItineraryContentType">
     <xs:annotation>
@@ -293,7 +293,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== BusinessRejectionType                                                           -->
+  <!--===== BusinessRejectionType                                                     -->
   <!--================================================================================-->
   <xs:simpleType name="BusinessRejectionTypeContentType">
     <xs:annotation>
@@ -306,7 +306,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== CancelEnquiryNotificationDateAndTime                                            -->
+  <!--===== CancelEnquiryNotificationDateAndTime                                      -->
   <!--================================================================================-->
   <xs:simpleType name="CancelEnquiryNotificationDateAndTimeContentType">
     <xs:annotation>
@@ -317,7 +317,7 @@
     <xs:restriction base="DateTimeType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== CancelEnquiryNotificationText                                                   -->
+  <!--===== CancelEnquiryNotificationText                                             -->
   <!--================================================================================-->
   <xs:simpleType name="CancelEnquiryNotificationTextContentType">
     <xs:annotation>
@@ -328,7 +328,7 @@
     <xs:restriction base="AlphaNumeric_MAX512" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== City                                                                            -->
+  <!--===== City                                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="CityContentType01">
     <xs:annotation>
@@ -355,7 +355,7 @@
     <xs:restriction base="AlphaNumeric_MAX35_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Code                                                                            -->
+  <!--===== Code                                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="CodeContentType01">
     <xs:annotation>
@@ -416,7 +416,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== CollectionDate                                                                  -->
+  <!--===== CollectionDate                                                            -->
   <!--================================================================================-->
   <xs:simpleType name="CollectionDateContentType">
     <xs:annotation>
@@ -427,7 +427,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== CombinedNomenclatureCode                                                        -->
+  <!--===== CombinedNomenclatureCode                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="CombinedNomenclatureCodeContentType01">
     <xs:annotation>
@@ -446,7 +446,7 @@
     <xs:restriction base="AlphaNumeric_2_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== CommunicationLanguageAtDeparture                                                -->
+  <!--===== CommunicationLanguageAtDeparture                                          -->
   <!--================================================================================-->
   <xs:simpleType name="CommunicationLanguageAtDepartureContentType">
     <xs:annotation>
@@ -457,7 +457,7 @@
     <xs:restriction base="LanguageCodeType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== CommunicationLanguageAtDestination                                              -->
+  <!--===== CommunicationLanguageAtDestination                                        -->
   <!--================================================================================-->
   <xs:simpleType name="CommunicationLanguageAtDestinationContentType">
     <xs:annotation>
@@ -465,10 +465,12 @@
         <usedBy>Used by 1/91 messages: CC007C</usedBy>
       </xs:documentation>
     </xs:annotation>
-    <xs:restriction base="LanguageCodeType" />
+    <xs:restriction base="xs:token">
+      <xs:pattern value="[A-Za-z]{2}" />
+    </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ComplementOfInformation                                                         -->
+  <!--===== ComplementOfInformation                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="ComplementOfInformationContentType01">
     <xs:annotation>
@@ -487,7 +489,7 @@
     <xs:restriction base="AlphaNumeric_MAX35_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== CompleteControl                                                                 -->
+  <!--===== CompleteControl                                                           -->
   <!--================================================================================-->
   <xs:simpleType name="CompleteControlContentType">
     <xs:annotation>
@@ -500,7 +502,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Conform                                                                         -->
+  <!--===== Conform                                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="ConformContentType">
     <xs:annotation>
@@ -513,7 +515,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ContactDetailsInCountryOfCompetentAuthority                                     -->
+  <!--===== ContactDetailsInCountryOfCompetentAuthority                               -->
   <!--================================================================================-->
   <xs:simpleType name="ContactDetailsInCountryOfCompetentAuthorityContentType">
     <xs:annotation>
@@ -526,7 +528,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ContainerIdentificationNumber                                                   -->
+  <!--===== ContainerIdentificationNumber                                             -->
   <!--================================================================================-->
   <xs:simpleType name="ContainerIdentificationNumberContentType01">
     <xs:annotation>
@@ -545,7 +547,7 @@
     <xs:restriction base="ContainerIdentificationNumber_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ContainerIndicator                                                              -->
+  <!--===== ContainerIndicator                                                        -->
   <!--================================================================================-->
   <xs:simpleType name="ContainerIndicatorContentType">
     <xs:annotation>
@@ -558,7 +560,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ContinueUnloading                                                               -->
+  <!--===== ContinueUnloading                                                         -->
   <!--================================================================================-->
   <xs:simpleType name="ContinueUnloadingContentType">
     <xs:annotation>
@@ -569,7 +571,7 @@
     <xs:restriction base="NumericWithoutZero_1" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ControlledBy                                                                    -->
+  <!--===== ControlledBy                                                              -->
   <!--================================================================================-->
   <xs:simpleType name="ControlledByContentType01">
     <xs:annotation>
@@ -588,7 +590,7 @@
     <xs:restriction base="Alphanumeric_Max35" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ControlNotificationDateAndTime                                                  -->
+  <!--===== ControlNotificationDateAndTime                                            -->
   <!--================================================================================-->
   <xs:simpleType name="ControlNotificationDateAndTimeContentType">
     <xs:annotation>
@@ -599,7 +601,7 @@
     <xs:restriction base="DateTimeType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ConveyanceReferenceNumber                                                       -->
+  <!--===== ConveyanceReferenceNumber                                                 -->
   <!--================================================================================-->
   <xs:simpleType name="ConveyanceReferenceNumberContentType01">
     <xs:annotation>
@@ -626,7 +628,7 @@
     <xs:restriction base="ConveyanceReferenceNumber35" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== CopyGiven                                                                       -->
+  <!--===== CopyGiven                                                                 -->
   <!--================================================================================-->
   <xs:simpleType name="CopyGivenContentType">
     <xs:annotation>
@@ -639,7 +641,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Counter                                                                         -->
+  <!--===== Counter                                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="CounterContentType">
     <xs:annotation>
@@ -650,7 +652,7 @@
     <xs:restriction base="NumericWithZero_9" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Country                                                                         -->
+  <!--===== Country                                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="CountryContentType">
     <xs:annotation>
@@ -661,7 +663,7 @@
     <xs:restriction base="CountryCodeType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== CountryOfDestination                                                            -->
+  <!--===== CountryOfDestination                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="CountryOfDestinationContentType">
     <xs:annotation>
@@ -669,21 +671,23 @@
         <usedBy>Used by 13/91 messages: CC013C, CC015C, CC017C, CC029C, CC043C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C</usedBy>
       </xs:documentation>
     </xs:annotation>
-    <xs:restriction base="CountryCodeType" />
+    <xs:restriction base="xs:token">
+      <xs:pattern value="[A-Za-z]{2}" />
+    </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== CountryOfDispatch                                                               -->
+  <!--===== CountryOfDispatch                                                         -->
   <!--================================================================================-->
   <xs:simpleType name="CountryOfDispatchContentType">
     <xs:annotation>
       <xs:documentation>
-        <usedBy>Used by 12/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C</usedBy>
+        <usedBy>Used by 8/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD012C, CD038C</usedBy>
       </xs:documentation>
     </xs:annotation>
-    <xs:restriction base="CountryCodeType" />
+    <xs:restriction base="Alpha_2" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== CoveredAmount                                                                   -->
+  <!--===== CoveredAmount                                                             -->
   <!--================================================================================-->
   <xs:simpleType name="CoveredAmountContentType">
     <xs:annotation>
@@ -694,7 +698,7 @@
     <xs:restriction base="DecimalWithoutZero_16_2" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Currency                                                                        -->
+  <!--===== Currency                                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="CurrencyContentType">
     <xs:annotation>
@@ -707,7 +711,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== CusCode                                                                         -->
+  <!--===== CusCode                                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="CusCodeContentType">
     <xs:annotation>
@@ -720,7 +724,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== CustomsOfficeAtBorderReferenceNumber                                            -->
+  <!--===== CustomsOfficeAtBorderReferenceNumber                                      -->
   <!--================================================================================-->
   <xs:simpleType name="CustomsOfficeAtBorderReferenceNumberContentType">
     <xs:annotation>
@@ -733,7 +737,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Date                                                                            -->
+  <!--===== Date                                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="DateContentType">
     <xs:annotation>
@@ -744,7 +748,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Decision                                                                        -->
+  <!--===== Decision                                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="DecisionContentType">
     <xs:annotation>
@@ -757,7 +761,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== DecisionDateAndTime                                                             -->
+  <!--===== DecisionDateAndTime                                                       -->
   <!--================================================================================-->
   <xs:simpleType name="DecisionDateAndTimeContentType">
     <xs:annotation>
@@ -768,7 +772,7 @@
     <xs:restriction base="DateTimeType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== DeclarationAcceptanceDate                                                       -->
+  <!--===== DeclarationAcceptanceDate                                                 -->
   <!--================================================================================-->
   <xs:simpleType name="DeclarationAcceptanceDateContentType">
     <xs:annotation>
@@ -779,7 +783,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== DeclarationGoodsItemNumber                                                      -->
+  <!--===== DeclarationGoodsItemNumber                                                -->
   <!--================================================================================-->
   <xs:simpleType name="DeclarationGoodsItemNumberContentType01">
     <xs:annotation>
@@ -798,7 +802,7 @@
     <xs:restriction base="DeclarationGoodsItemNumberType_WithZero" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== DeclarationSubmissionDateAndTime                                                -->
+  <!--===== DeclarationSubmissionDateAndTime                                          -->
   <!--================================================================================-->
   <xs:simpleType name="DeclarationSubmissionDateAndTimeContentType">
     <xs:annotation>
@@ -809,7 +813,7 @@
     <xs:restriction base="DateTimeType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== DeclarationType                                                                 -->
+  <!--===== DeclarationType                                                           -->
   <!--================================================================================-->
   <xs:simpleType name="DeclarationTypeContentType01">
     <xs:annotation>
@@ -830,7 +834,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Description                                                                     -->
+  <!--===== Description                                                               -->
   <!--================================================================================-->
   <xs:simpleType name="DescriptionContentType">
     <xs:annotation>
@@ -841,7 +845,7 @@
     <xs:restriction base="AlphaNumeric_MAX512" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== DescriptionOfGoods                                                              -->
+  <!--===== DescriptionOfGoods                                                        -->
   <!--================================================================================-->
   <xs:simpleType name="DescriptionOfGoodsContentType01">
     <xs:annotation>
@@ -860,7 +864,7 @@
     <xs:restriction base="AlphaNumeric_MAX512_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== DiscrepanciesNotificationDate                                                   -->
+  <!--===== DiscrepanciesNotificationDate                                             -->
   <!--================================================================================-->
   <xs:simpleType name="DiscrepanciesNotificationDateContentType">
     <xs:annotation>
@@ -871,7 +875,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== DiscrepanciesNotificationText                                                   -->
+  <!--===== DiscrepanciesNotificationText                                             -->
   <!--================================================================================-->
   <xs:simpleType name="DiscrepanciesNotificationTextContentType">
     <xs:annotation>
@@ -882,7 +886,7 @@
     <xs:restriction base="AlphaNumeric_MAX512" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== DiscrepanciesResolved                                                           -->
+  <!--===== DiscrepanciesResolved                                                     -->
   <!--================================================================================-->
   <xs:simpleType name="DiscrepanciesResolvedContentType">
     <xs:annotation>
@@ -895,7 +899,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== DocumentLineItemNumber                                                          -->
+  <!--===== DocumentLineItemNumber                                                    -->
   <!--================================================================================-->
   <xs:simpleType name="DocumentLineItemNumberContentType">
     <xs:annotation>
@@ -906,7 +910,7 @@
     <xs:restriction base="NumericWithoutZero_5" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== DocumentType                                                                    -->
+  <!--===== DocumentType                                                              -->
   <!--================================================================================-->
   <xs:simpleType name="DocumentTypeContentType">
     <xs:annotation>
@@ -919,7 +923,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== EMailAddress                                                                    -->
+  <!--===== EMailAddress                                                              -->
   <!--================================================================================-->
   <xs:simpleType name="EMailAddressContentType01">
     <xs:annotation>
@@ -938,7 +942,7 @@
     <xs:restriction base="EmailAddressType256_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== EndDateAndTime                                                                  -->
+  <!--===== EndDateAndTime                                                            -->
   <!--================================================================================-->
   <xs:simpleType name="EndDateAndTimeContentType">
     <xs:annotation>
@@ -949,7 +953,7 @@
     <xs:restriction base="DateTimeType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== EnquiryRequestDate                                                              -->
+  <!--===== EnquiryRequestDate                                                        -->
   <!--================================================================================-->
   <xs:simpleType name="EnquiryRequestDateContentType">
     <xs:annotation>
@@ -960,7 +964,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== EnquiryResponseDate                                                             -->
+  <!--===== EnquiryResponseDate                                                       -->
   <!--================================================================================-->
   <xs:simpleType name="EnquiryResponseDateContentType">
     <xs:annotation>
@@ -971,7 +975,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ErrorCode                                                                       -->
+  <!--===== ErrorCode                                                                 -->
   <!--================================================================================-->
   <xs:simpleType name="ErrorCodeContentType">
     <xs:annotation>
@@ -984,7 +988,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ErrorColumnNumber                                                               -->
+  <!--===== ErrorColumnNumber                                                         -->
   <!--================================================================================-->
   <xs:simpleType name="ErrorColumnNumberContentType">
     <xs:annotation>
@@ -995,7 +999,7 @@
     <xs:restriction base="NumericWithZero_9" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ErrorLineNumber                                                                 -->
+  <!--===== ErrorLineNumber                                                           -->
   <!--================================================================================-->
   <xs:simpleType name="ErrorLineNumberContentType">
     <xs:annotation>
@@ -1006,7 +1010,7 @@
     <xs:restriction base="NumericWithZero_9" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ErrorPointer                                                                    -->
+  <!--===== ErrorPointer                                                              -->
   <!--================================================================================-->
   <xs:simpleType name="ErrorPointerContentType">
     <xs:annotation>
@@ -1017,7 +1021,7 @@
     <xs:restriction base="AlphaNumeric_MAX512" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ErrorReason                                                                     -->
+  <!--===== ErrorReason                                                               -->
   <!--================================================================================-->
   <xs:simpleType name="ErrorReasonContentType">
     <xs:annotation>
@@ -1028,7 +1032,7 @@
     <xs:restriction base="AlphaNumeric_MAX7" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ErrorText                                                                       -->
+  <!--===== ErrorText                                                                 -->
   <!--================================================================================-->
   <xs:simpleType name="ErrorTextContentType">
     <xs:annotation>
@@ -1039,7 +1043,7 @@
     <xs:restriction base="AlphaNumeric_MAX512" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ExpiryDate                                                                      -->
+  <!--===== ExpiryDate                                                                -->
   <!--================================================================================-->
   <xs:simpleType name="ExpiryDateContentType">
     <xs:annotation>
@@ -1050,7 +1054,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Explanation                                                                     -->
+  <!--===== Explanation                                                               -->
   <!--================================================================================-->
   <xs:simpleType name="ExplanationContentType">
     <xs:annotation>
@@ -1063,7 +1067,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ExportDeclarationGoodsItemNumber                                                -->
+  <!--===== ExportDeclarationGoodsItemNumber                                          -->
   <!--================================================================================-->
   <xs:simpleType name="ExportDeclarationGoodsItemNumberContentType">
     <xs:annotation>
@@ -1074,7 +1078,7 @@
     <xs:restriction base="AES-P1_DeclarationGoodsItemNumberType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Exposure                                                                        -->
+  <!--===== Exposure                                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="ExposureContentType">
     <xs:annotation>
@@ -1085,7 +1089,7 @@
     <xs:restriction base="DecimalWithZero_16_2" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ExposureCounter                                                                 -->
+  <!--===== ExposureCounter                                                           -->
   <!--================================================================================-->
   <xs:simpleType name="ExposureCounterContentType">
     <xs:annotation>
@@ -1096,7 +1100,7 @@
     <xs:restriction base="NumericWithoutZero_8" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Flag                                                                            -->
+  <!--===== Flag                                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="FlagContentType">
     <xs:annotation>
@@ -1109,7 +1113,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Functionality                                                                   -->
+  <!--===== Functionality                                                             -->
   <!--================================================================================-->
   <xs:simpleType name="FunctionalityContentType">
     <xs:annotation>
@@ -1122,7 +1126,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== GlobalValidationResponse                                                        -->
+  <!--===== GlobalValidationResponse                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="GlobalValidationResponseContentType">
     <xs:annotation>
@@ -1135,18 +1139,28 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== GoodsItemNumber                                                                 -->
+  <!--===== GoodsItemNumber                                                           -->
   <!--================================================================================-->
-  <xs:simpleType name="GoodsItemNumberContentType">
+  <xs:simpleType name="GoodsItemNumberContentType01">
     <xs:annotation>
       <xs:documentation>
-        <usedBy>Used by 17/91 messages: CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C</usedBy>
+        <usedBy>Used by 13/91 messages: CC013C, CC015C, CC017C, CC029C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C</usedBy>
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="NumericWithoutZero_5" />
   </xs:simpleType>
+  <xs:simpleType name="GoodsItemNumberContentType02">
+    <xs:annotation>
+      <xs:documentation>
+        <usedBy>Used by 16/91 messages: CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C</usedBy>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:pattern value="[0-9]{1,5}" />
+    </xs:restriction>
+  </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Grn                                                                             -->
+  <!--===== Grn                                                                       -->
   <!--================================================================================-->
   <xs:simpleType name="GrnContentType">
     <xs:annotation>
@@ -1157,12 +1171,12 @@
     <xs:restriction base="GRNType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== GrossMass                                                                       -->
+  <!--===== GrossMass                                                                 -->
   <!--================================================================================-->
   <xs:simpleType name="GrossMassContentType01">
     <xs:annotation>
       <xs:documentation>
-        <usedBy>Used by 13/91 messages: CC013C, CC015C, CC017C, CC029C, CC043C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C</usedBy>
+        <usedBy>Used by 15/91 messages: CC013C, CC015C, CC017C, CC029C, CC043C, CC044C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C</usedBy>
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="DecimalWithoutZero_16_6" />
@@ -1176,7 +1190,7 @@
     <xs:restriction base="DecimalWithZero_16_6" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== GuaranteeAmount                                                                 -->
+  <!--===== GuaranteeAmount                                                           -->
   <!--================================================================================-->
   <xs:simpleType name="GuaranteeAmountContentType">
     <xs:annotation>
@@ -1187,7 +1201,7 @@
     <xs:restriction base="DecimalWithZero_16_2" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== GuaranteeMonitoringCode                                                         -->
+  <!--===== GuaranteeMonitoringCode                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="GuaranteeMonitoringCodeContentType">
     <xs:annotation>
@@ -1200,7 +1214,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== GuaranteeNotValidForCountry                                                     -->
+  <!--===== GuaranteeNotValidForCountry                                               -->
   <!--================================================================================-->
   <xs:simpleType name="GuaranteeNotValidForCountryContentType">
     <xs:annotation>
@@ -1213,7 +1227,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== GuaranteeNotValidIn                                                             -->
+  <!--===== GuaranteeNotValidIn                                                       -->
   <!--================================================================================-->
   <xs:simpleType name="GuaranteeNotValidInContentType">
     <xs:annotation>
@@ -1226,7 +1240,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== GuaranteeType                                                                   -->
+  <!--===== GuaranteeType                                                             -->
   <!--================================================================================-->
   <xs:simpleType name="GuaranteeTypeContentType">
     <xs:annotation>
@@ -1237,7 +1251,7 @@
     <xs:restriction base="AlphanumericCapital1Type" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== GuarantorNotificationDate                                                       -->
+  <!--===== GuarantorNotificationDate                                                 -->
   <!--================================================================================-->
   <xs:simpleType name="GuarantorNotificationDateContentType">
     <xs:annotation>
@@ -1248,7 +1262,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== GuarantorNotificationText                                                       -->
+  <!--===== GuarantorNotificationText                                                 -->
   <!--================================================================================-->
   <xs:simpleType name="GuarantorNotificationTextContentType">
     <xs:annotation>
@@ -1259,7 +1273,7 @@
     <xs:restriction base="AlphaNumeric_MAX512" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== HarmonizedSystemSubHeadingCode                                                  -->
+  <!--===== HarmonizedSystemSubHeadingCode                                            -->
   <!--================================================================================-->
   <xs:simpleType name="HarmonizedSystemSubHeadingCodeContentType">
     <xs:annotation>
@@ -1272,7 +1286,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== HouseNumber                                                                     -->
+  <!--===== HouseNumber                                                               -->
   <!--================================================================================-->
   <xs:simpleType name="HouseNumberContentType01">
     <xs:annotation>
@@ -1291,7 +1305,7 @@
     <xs:restriction base="AlphaNumeric_MAX17_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== IdentificationNumber                                                            -->
+  <!--===== IdentificationNumber                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="IdentificationNumberContentType01">
     <xs:annotation>
@@ -1342,7 +1356,7 @@
     <xs:restriction base="AlphaNumeric_MAX35_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Identifier                                                                      -->
+  <!--===== Identifier                                                                -->
   <!--================================================================================-->
   <xs:simpleType name="IdentifierContentType01">
     <xs:annotation>
@@ -1361,7 +1375,7 @@
     <xs:restriction base="AlphaNumeric_MAX20_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== IncidentFlag                                                                    -->
+  <!--===== IncidentFlag                                                              -->
   <!--================================================================================-->
   <xs:simpleType name="IncidentFlagContentType">
     <xs:annotation>
@@ -1374,7 +1388,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== IncidentNotificationDateAndTime                                                 -->
+  <!--===== IncidentNotificationDateAndTime                                           -->
   <!--================================================================================-->
   <xs:simpleType name="IncidentNotificationDateAndTimeContentType">
     <xs:annotation>
@@ -1385,7 +1399,7 @@
     <xs:restriction base="DateTimeType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== InformationAvailableFromTrader                                                  -->
+  <!--===== InformationAvailableFromTrader                                            -->
   <!--================================================================================-->
   <xs:simpleType name="InformationAvailableFromTraderContentType">
     <xs:annotation>
@@ -1398,7 +1412,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== InformationCode                                                                 -->
+  <!--===== InformationCode                                                           -->
   <!--================================================================================-->
   <xs:simpleType name="InformationCodeContentType">
     <xs:annotation>
@@ -1411,7 +1425,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== InitiatedByCustoms                                                              -->
+  <!--===== InitiatedByCustoms                                                        -->
   <!--================================================================================-->
   <xs:simpleType name="InitiatedByCustomsContentType">
     <xs:annotation>
@@ -1424,7 +1438,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== InlandModeOfTransport                                                           -->
+  <!--===== InlandModeOfTransport                                                     -->
   <!--================================================================================-->
   <xs:simpleType name="InlandModeOfTransportContentType">
     <xs:annotation>
@@ -1437,7 +1451,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== InvalidityDate                                                                  -->
+  <!--===== InvalidityDate                                                            -->
   <!--================================================================================-->
   <xs:simpleType name="InvalidityDateContentType">
     <xs:annotation>
@@ -1448,7 +1462,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== InvalidityReasonCode                                                            -->
+  <!--===== InvalidityReasonCode                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="InvalidityReasonCodeContentType">
     <xs:annotation>
@@ -1461,7 +1475,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== InvalidityReasonText                                                            -->
+  <!--===== InvalidityReasonText                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="InvalidityReasonTextContentType">
     <xs:annotation>
@@ -1472,7 +1486,7 @@
     <xs:restriction base="AlphaNumeric_MAX512" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== IssueDate                                                                       -->
+  <!--===== IssueDate                                                                 -->
   <!--================================================================================-->
   <xs:simpleType name="IssueDateContentType">
     <xs:annotation>
@@ -1483,7 +1497,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Justification                                                                   -->
+  <!--===== Justification                                                             -->
   <!--================================================================================-->
   <xs:simpleType name="JustificationContentType01">
     <xs:annotation>
@@ -1502,7 +1516,7 @@
     <xs:restriction base="AlphaNumeric_MAX512_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Latitude                                                                        -->
+  <!--===== Latitude                                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="LatitudeContentType">
     <xs:annotation>
@@ -1513,7 +1527,7 @@
     <xs:restriction base="GNSSLatitude" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== LiabilityLiberationDate                                                         -->
+  <!--===== LiabilityLiberationDate                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="LiabilityLiberationDateContentType">
     <xs:annotation>
@@ -1524,7 +1538,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== LimitDate                                                                       -->
+  <!--===== LimitDate                                                                 -->
   <!--================================================================================-->
   <xs:simpleType name="LimitDateContentType">
     <xs:annotation>
@@ -1535,7 +1549,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== LimitForResponseDate                                                            -->
+  <!--===== LimitForResponseDate                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="LimitForResponseDateContentType">
     <xs:annotation>
@@ -1546,7 +1560,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== LimitForTheEnquiryResponseDate                                                  -->
+  <!--===== LimitForTheEnquiryResponseDate                                            -->
   <!--================================================================================-->
   <xs:simpleType name="LimitForTheEnquiryResponseDateContentType">
     <xs:annotation>
@@ -1557,7 +1571,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Location                                                                        -->
+  <!--===== Location                                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="LocationContentType01">
     <xs:annotation>
@@ -1576,7 +1590,7 @@
     <xs:restriction base="Alphanumeric_Max35" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== LockDate                                                                        -->
+  <!--===== LockDate                                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="LockDateContentType">
     <xs:annotation>
@@ -1587,7 +1601,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Longitude                                                                       -->
+  <!--===== Longitude                                                                 -->
   <!--================================================================================-->
   <xs:simpleType name="LongitudeContentType">
     <xs:annotation>
@@ -1598,7 +1612,7 @@
     <xs:restriction base="GNSSLongitude" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Lrn                                                                             -->
+  <!--===== Lrn                                                                       -->
   <!--================================================================================-->
   <xs:simpleType name="LRNContentType01">
     <xs:annotation>
@@ -1625,7 +1639,7 @@
     <xs:restriction base="AlphaNumeric_MAX22_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== MasterAccessCode                                                                -->
+  <!--===== MasterAccessCode                                                          -->
   <!--================================================================================-->
   <xs:simpleType name="MasterAccessCodeContentType">
     <xs:annotation>
@@ -1636,7 +1650,7 @@
     <xs:restriction base="AlphaNumeric_MAX4_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== MeasurementUnitAndQualifier                                                     -->
+  <!--===== MeasurementUnitAndQualifier                                               -->
   <!--================================================================================-->
   <xs:simpleType name="MeasurementUnitAndQualifierContentType">
     <xs:annotation>
@@ -1649,7 +1663,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== MessageType                                                                     -->
+  <!--===== MessageType                                                               -->
   <!--================================================================================-->
   <xs:simpleType name="MessageTypeContentType">
     <xs:annotation>
@@ -1662,7 +1676,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== MethodOfPayment                                                                 -->
+  <!--===== MethodOfPayment                                                           -->
   <!--================================================================================-->
   <xs:simpleType name="MethodOfPaymentContentType">
     <xs:annotation>
@@ -1673,7 +1687,7 @@
     <xs:restriction base="AlphaCapital1Type" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ModeOfTransportAtTheBorder                                                      -->
+  <!--===== ModeOfTransportAtTheBorder                                                -->
   <!--================================================================================-->
   <xs:simpleType name="ModeOfTransportAtTheBorderContentType">
     <xs:annotation>
@@ -1686,7 +1700,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Month                                                                           -->
+  <!--===== Month                                                                     -->
   <!--================================================================================-->
   <xs:simpleType name="MonthContentType">
     <xs:annotation>
@@ -1699,7 +1713,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Mrn                                                                             -->
+  <!--===== Mrn                                                                       -->
   <!--================================================================================-->
   <xs:simpleType name="MRNContentType01">
     <xs:annotation>
@@ -1744,7 +1758,7 @@
     <xs:restriction base="MRNType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Name                                                                            -->
+  <!--===== Name                                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="NameContentType01">
     <xs:annotation>
@@ -1763,7 +1777,7 @@
     <xs:restriction base="AlphaNumeric_MAX70_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Nationality                                                                     -->
+  <!--===== Nationality                                                               -->
   <!--================================================================================-->
   <xs:simpleType name="NationalityContentType">
     <xs:annotation>
@@ -1774,7 +1788,7 @@
     <xs:restriction base="CountryCodeType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== NetMass                                                                         -->
+  <!--===== NetMass                                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="NetMassContentType">
     <xs:annotation>
@@ -1785,7 +1799,7 @@
     <xs:restriction base="DecimalWithoutZero_16_6" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== NoReleaseMotivationCode                                                         -->
+  <!--===== NoReleaseMotivationCode                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="NoReleaseMotivationCodeContentType">
     <xs:annotation>
@@ -1798,7 +1812,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== NoReleaseMotivationText                                                         -->
+  <!--===== NoReleaseMotivationText                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="NoReleaseMotivationTextContentType">
     <xs:annotation>
@@ -1809,7 +1823,7 @@
     <xs:restriction base="AlphaNumeric_MAX512" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== NotificationType                                                                -->
+  <!--===== NotificationType                                                          -->
   <!--================================================================================-->
   <xs:simpleType name="NotificationTypeContentType">
     <xs:annotation>
@@ -1822,7 +1836,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== NumberOfCertificates                                                            -->
+  <!--===== NumberOfCertificates                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="NumberOfCertificatesContentType">
     <xs:annotation>
@@ -1833,7 +1847,7 @@
     <xs:restriction base="NumericWithZero_8" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== NumberOfPackages                                                                -->
+  <!--===== NumberOfPackages                                                          -->
   <!--================================================================================-->
   <xs:simpleType name="NumberOfPackagesContentType01">
     <xs:annotation>
@@ -1852,7 +1866,7 @@
     <xs:restriction base="NumericWithoutZero_8" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== NumberOfSeals                                                                   -->
+  <!--===== NumberOfSeals                                                             -->
   <!--================================================================================-->
   <xs:simpleType name="NumberOfSealsContentType">
     <xs:annotation>
@@ -1863,7 +1877,7 @@
     <xs:restriction base="NumericWithZero_4" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Operation                                                                       -->
+  <!--===== Operation                                                                 -->
   <!--================================================================================-->
   <xs:simpleType name="OperationContentType">
     <xs:annotation>
@@ -1876,7 +1890,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== OriginalAttributeValue                                                          -->
+  <!--===== OriginalAttributeValue                                                    -->
   <!--================================================================================-->
   <xs:simpleType name="OriginalAttributeValueContentType">
     <xs:annotation>
@@ -1887,7 +1901,7 @@
     <xs:restriction base="AlphaNumeric_MAX512" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== OtherCountry                                                                    -->
+  <!--===== OtherCountry                                                              -->
   <!--================================================================================-->
   <xs:simpleType name="OtherCountryContentType">
     <xs:annotation>
@@ -1895,10 +1909,12 @@
         <usedBy>Used by 1/91 messages: CD411D</usedBy>
       </xs:documentation>
     </xs:annotation>
-    <xs:restriction base="CountryCodeType" />
+    <xs:restriction base="xs:token">
+      <xs:pattern value="[A-Za-z]{2}" />
+    </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== OtherGuaranteeReference                                                         -->
+  <!--===== OtherGuaranteeReference                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="OtherGuaranteeReferenceContentType01">
     <xs:annotation>
@@ -1917,7 +1933,7 @@
     <xs:restriction base="AlphaNumeric_MAX35_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== OtherThingsToReport                                                             -->
+  <!--===== OtherThingsToReport                                                       -->
   <!--================================================================================-->
   <xs:simpleType name="OtherThingsToReportContentType01">
     <xs:annotation>
@@ -1936,7 +1952,7 @@
     <xs:restriction base="AlphaNumeric_MAX512_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== PassageDate                                                                     -->
+  <!--===== PassageDate                                                               -->
   <!--================================================================================-->
   <xs:simpleType name="PassageDateContentType">
     <xs:annotation>
@@ -1947,7 +1963,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== PercentageOfReferenceAmount                                                     -->
+  <!--===== PercentageOfReferenceAmount                                               -->
   <!--================================================================================-->
   <xs:simpleType name="PercentageOfReferenceAmountContentType01">
     <xs:annotation>
@@ -1966,7 +1982,7 @@
     <xs:restriction base="NumericWithZero_3" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== PeriodFromDate                                                                  -->
+  <!--===== PeriodFromDate                                                            -->
   <!--================================================================================-->
   <xs:simpleType name="PeriodFromDateContentType">
     <xs:annotation>
@@ -1977,7 +1993,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== PeriodToDate                                                                    -->
+  <!--===== PeriodToDate                                                              -->
   <!--================================================================================-->
   <xs:simpleType name="PeriodToDateContentType">
     <xs:annotation>
@@ -1988,7 +2004,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== PhoneNumber                                                                     -->
+  <!--===== PhoneNumber                                                               -->
   <!--================================================================================-->
   <xs:simpleType name="PhoneNumberContentType01">
     <xs:annotation>
@@ -2009,7 +2025,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Place                                                                           -->
+  <!--===== Place                                                                     -->
   <!--================================================================================-->
   <xs:simpleType name="PlaceContentType01">
     <xs:annotation>
@@ -2028,7 +2044,7 @@
     <xs:restriction base="Alphanumeric_Max35" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Postcode                                                                        -->
+  <!--===== Postcode                                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="PostcodeContentType01">
     <xs:annotation>
@@ -2047,7 +2063,7 @@
     <xs:restriction base="AlphaNumeric_MAX17_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== PresentationOfTheGoodsDateAndTime                                               -->
+  <!--===== PresentationOfTheGoodsDateAndTime                                         -->
   <!--================================================================================-->
   <xs:simpleType name="PresentationOfTheGoodsDateAndTimeContentType">
     <xs:annotation>
@@ -2058,7 +2074,7 @@
     <xs:restriction base="DateTimeType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== QualifierOfIdentification                                                       -->
+  <!--===== QualifierOfIdentification                                                 -->
   <!--================================================================================-->
   <xs:simpleType name="QualifierOfIdentificationContentType">
     <xs:annotation>
@@ -2071,7 +2087,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Quantity                                                                        -->
+  <!--===== Quantity                                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="QuantityContentType">
     <xs:annotation>
@@ -2082,7 +2098,7 @@
     <xs:restriction base="DecimalWithoutZero_16_6" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== QueryIdentifier                                                                 -->
+  <!--===== QueryIdentifier                                                           -->
   <!--================================================================================-->
   <xs:simpleType name="QueryIdentifierContentType">
     <xs:annotation>
@@ -2095,7 +2111,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== RecoveryAcceptance                                                              -->
+  <!--===== RecoveryAcceptance                                                        -->
   <!--================================================================================-->
   <xs:simpleType name="RecoveryAcceptanceContentType">
     <xs:annotation>
@@ -2103,12 +2119,10 @@
         <usedBy>Used by 1/91 messages: CD151C</usedBy>
       </xs:documentation>
     </xs:annotation>
-    <xs:restriction base="xs:token">
-      <xs:pattern value="[0-9]{1}" />
-    </xs:restriction>
+    <xs:restriction base="Numeric_1" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== RecoveryCommunicationDate                                                       -->
+  <!--===== RecoveryCommunicationDate                                                 -->
   <!--================================================================================-->
   <xs:simpleType name="RecoveryCommunicationDateContentType">
     <xs:annotation>
@@ -2119,7 +2133,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== RecoveryNotificationDate                                                        -->
+  <!--===== RecoveryNotificationDate                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="RecoveryNotificationDateContentType">
     <xs:annotation>
@@ -2130,7 +2144,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== RecoveryNotificationText                                                        -->
+  <!--===== RecoveryNotificationText                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="RecoveryNotificationTextContentType">
     <xs:annotation>
@@ -2141,7 +2155,7 @@
     <xs:restriction base="AlphaNumeric_MAX512" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ReducedDatasetIndicator                                                         -->
+  <!--===== ReducedDatasetIndicator                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="ReducedDatasetIndicatorContentType">
     <xs:annotation>
@@ -2154,7 +2168,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ReferenceAmount                                                                 -->
+  <!--===== ReferenceAmount                                                           -->
   <!--================================================================================-->
   <xs:simpleType name="ReferenceAmountContentType">
     <xs:annotation>
@@ -2165,7 +2179,7 @@
     <xs:restriction base="DecimalWithZero_16_2" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ReferenceNumber                                                                 -->
+  <!--===== ReferenceNumber                                                           -->
   <!--================================================================================-->
   <xs:simpleType name="ReferenceNumberContentType01">
     <xs:annotation>
@@ -2208,7 +2222,7 @@
     <xs:restriction base="CORefNumType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ReferenceNumberUCR                                                              -->
+  <!--===== ReferenceNumberUCR                                                        -->
   <!--================================================================================-->
   <xs:simpleType name="ReferenceNumberUCRContentType01">
     <xs:annotation>
@@ -2235,7 +2249,7 @@
     <xs:restriction base="UCRReferenceNumber70" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== RejectionCode                                                                   -->
+  <!--===== RejectionCode                                                             -->
   <!--================================================================================-->
   <xs:simpleType name="RejectionCodeContentType">
     <xs:annotation>
@@ -2248,7 +2262,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== RejectionDateAndTime                                                            -->
+  <!--===== RejectionDateAndTime                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="RejectionDateAndTimeContentType">
     <xs:annotation>
@@ -2259,7 +2273,7 @@
     <xs:restriction base="DateTimeType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== RejectionReason                                                                 -->
+  <!--===== RejectionReason                                                           -->
   <!--================================================================================-->
   <xs:simpleType name="RejectionReasonContentType">
     <xs:annotation>
@@ -2270,7 +2284,7 @@
     <xs:restriction base="AlphaNumeric_MAX512" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ReleaseDate                                                                     -->
+  <!--===== ReleaseDate                                                               -->
   <!--================================================================================-->
   <xs:simpleType name="ReleaseDateContentType">
     <xs:annotation>
@@ -2281,7 +2295,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ReleaseIndicator                                                                -->
+  <!--===== ReleaseIndicator                                                          -->
   <!--================================================================================-->
   <xs:simpleType name="ReleaseIndicatorContentType">
     <xs:annotation>
@@ -2294,7 +2308,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ReleaseRequestDateAndTime                                                       -->
+  <!--===== ReleaseRequestDateAndTime                                                 -->
   <!--================================================================================-->
   <xs:simpleType name="ReleaseRequestDateAndTimeContentType">
     <xs:annotation>
@@ -2305,7 +2319,7 @@
     <xs:restriction base="DateTimeType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ReleaseRequested                                                                -->
+  <!--===== ReleaseRequested                                                          -->
   <!--================================================================================-->
   <xs:simpleType name="ReleaseRequestedContentType">
     <xs:annotation>
@@ -2318,7 +2332,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ReleaseType                                                                     -->
+  <!--===== ReleaseType                                                               -->
   <!--================================================================================-->
   <xs:simpleType name="ReleaseTypeContentType">
     <xs:annotation>
@@ -2331,7 +2345,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Remark                                                                          -->
+  <!--===== Remark                                                                    -->
   <!--================================================================================-->
   <xs:simpleType name="RemarkContentType">
     <xs:annotation>
@@ -2342,7 +2356,7 @@
     <xs:restriction base="AlphaNumeric_MAX512_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== RequestDateAndTime                                                              -->
+  <!--===== RequestDateAndTime                                                        -->
   <!--================================================================================-->
   <xs:simpleType name="RequestDateAndTimeContentType">
     <xs:annotation>
@@ -2353,7 +2367,7 @@
     <xs:restriction base="DateTimeType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== RequestOnNonArrivedMovementDate                                                 -->
+  <!--===== RequestOnNonArrivedMovementDate                                           -->
   <!--================================================================================-->
   <xs:simpleType name="RequestOnNonArrivedMovementDateContentType">
     <xs:annotation>
@@ -2364,7 +2378,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== RequestRejectionReasonCode                                                      -->
+  <!--===== RequestRejectionReasonCode                                                -->
   <!--================================================================================-->
   <xs:simpleType name="RequestRejectionReasonCodeContentType">
     <xs:annotation>
@@ -2377,7 +2391,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ResponseCode                                                                    -->
+  <!--===== ResponseCode                                                              -->
   <!--================================================================================-->
   <xs:simpleType name="ResponseCodeContentType">
     <xs:annotation>
@@ -2390,7 +2404,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ResponseDateAndTime                                                             -->
+  <!--===== ResponseDateAndTime                                                       -->
   <!--================================================================================-->
   <xs:simpleType name="ResponseDateAndTimeContentType">
     <xs:annotation>
@@ -2401,7 +2415,7 @@
     <xs:restriction base="DateTimeType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== RestrictedUseForSuspendedGoods                                                  -->
+  <!--===== RestrictedUseForSuspendedGoods                                            -->
   <!--================================================================================-->
   <xs:simpleType name="RestrictedUseForSuspendedGoodsContentType">
     <xs:annotation>
@@ -2414,7 +2428,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== RestrictedUseSuspendedGoods                                                     -->
+  <!--===== RestrictedUseSuspendedGoods                                               -->
   <!--================================================================================-->
   <xs:simpleType name="RestrictedUseSuspendedGoodsContentType">
     <xs:annotation>
@@ -2427,7 +2441,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ResultIndicator                                                                 -->
+  <!--===== ResultIndicator                                                           -->
   <!--================================================================================-->
   <xs:simpleType name="ResultIndicatorContentType">
     <xs:annotation>
@@ -2440,7 +2454,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ReturnCopyReturnedDate                                                          -->
+  <!--===== ReturnCopyReturnedDate                                                    -->
   <!--================================================================================-->
   <xs:simpleType name="ReturnCopyReturnedDateContentType">
     <xs:annotation>
@@ -2451,7 +2465,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== RiskAreaCode                                                                    -->
+  <!--===== RiskAreaCode                                                              -->
   <!--================================================================================-->
   <xs:simpleType name="RiskAreaCodeContentType">
     <xs:annotation>
@@ -2464,7 +2478,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Role                                                                            -->
+  <!--===== Role                                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="RoleContentType01">
     <xs:annotation>
@@ -2487,7 +2501,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Security                                                                        -->
+  <!--===== Security                                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="SecurityContentType">
     <xs:annotation>
@@ -2500,7 +2514,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== SecurityIndicatorFromExportDeclaration                                          -->
+  <!--===== SecurityIndicatorFromExportDeclaration                                    -->
   <!--================================================================================-->
   <xs:simpleType name="SecurityIndicatorFromExportDeclarationContentType">
     <xs:annotation>
@@ -2513,7 +2527,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== SequenceNumber                                                                  -->
+  <!--===== SequenceNumber                                                            -->
   <!--================================================================================-->
   <xs:simpleType name="SequenceNumberContentType">
     <xs:annotation>
@@ -2521,10 +2535,12 @@
         <usedBy>Used by 50/91 messages: CC007C, CC013C, CC015C, CC017C, CC022C, CC025C, CC029C, CC034C, CC037C, CC042C, CC043C, CC044C, CC048C, CC055C, CC060C, CC170C, CC182C, CC190C, CC191C, CC224C, CC225C, CC228C, CD001C, CD003C, CD010C, CD012C, CD018C, CD024C, CD038C, CD050C, CD063C, CD070C, CD071C, CD115C, CD144C, CD145C, CD150C, CD151C, CD160C, CD165C, CD180C, CD181C, CD200C, CD201C, CD203C, CD204C, CD205C, CD209C, CD411D, CD971C</usedBy>
       </xs:documentation>
     </xs:annotation>
-    <xs:restriction base="NumericWithoutZero_5" />
+    <xs:restriction base="xs:token">
+      <xs:pattern value="[0-9]{1,5}" />
+    </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ShippingMarks                                                                   -->
+  <!--===== ShippingMarks                                                             -->
   <!--================================================================================-->
   <xs:simpleType name="ShippingMarksContentType01">
     <xs:annotation>
@@ -2543,7 +2559,7 @@
     <xs:restriction base="AlphaNumeric_MAX512_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== SimplifiedProcedure                                                             -->
+  <!--===== SimplifiedProcedure                                                       -->
   <!--================================================================================-->
   <xs:simpleType name="SimplifiedProcedureContentType">
     <xs:annotation>
@@ -2556,7 +2572,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== SpecificCircumstanceIndicator                                                   -->
+  <!--===== SpecificCircumstanceIndicator                                             -->
   <!--================================================================================-->
   <xs:simpleType name="SpecificCircumstanceIndicatorContentType">
     <xs:annotation>
@@ -2569,7 +2585,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== StartDateAndTime                                                                -->
+  <!--===== StartDateAndTime                                                          -->
   <!--================================================================================-->
   <xs:simpleType name="StartDateAndTimeContentType">
     <xs:annotation>
@@ -2580,7 +2596,7 @@
     <xs:restriction base="DateTimeType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== StateOfSeals                                                                    -->
+  <!--===== StateOfSeals                                                              -->
   <!--================================================================================-->
   <xs:simpleType name="StateOfSealsContentType">
     <xs:annotation>
@@ -2593,7 +2609,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== StatisticsType                                                                  -->
+  <!--===== StatisticsType                                                            -->
   <!--================================================================================-->
   <xs:simpleType name="StatisticsTypeContentType">
     <xs:annotation>
@@ -2604,7 +2620,7 @@
     <xs:restriction base="Alphanumeric_4" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== StatisticsTypeSupport                                                           -->
+  <!--===== StatisticsTypeSupport                                                     -->
   <!--================================================================================-->
   <xs:simpleType name="StatisticsTypeSupportContentType">
     <xs:annotation>
@@ -2617,7 +2633,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Status                                                                          -->
+  <!--===== Status                                                                    -->
   <!--================================================================================-->
   <xs:simpleType name="StatusContentType01">
     <xs:annotation>
@@ -2648,7 +2664,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== StreetAndNumber                                                                 -->
+  <!--===== StreetAndNumber                                                           -->
   <!--================================================================================-->
   <xs:simpleType name="StreetAndNumberContentType01">
     <xs:annotation>
@@ -2667,7 +2683,7 @@
     <xs:restriction base="AlphaNumeric_MAX70_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== SupplementaryUnits                                                              -->
+  <!--===== SupplementaryUnits                                                        -->
   <!--================================================================================-->
   <xs:simpleType name="SupplementaryUnitsContentType">
     <xs:annotation>
@@ -2678,7 +2694,7 @@
     <xs:restriction base="DecimalWithoutZero_16_6" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== SystemCode                                                                      -->
+  <!--===== SystemCode                                                                -->
   <!--================================================================================-->
   <xs:simpleType name="SystemCodeContentType">
     <xs:annotation>
@@ -2691,7 +2707,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== TC11DeliveryDate                                                                -->
+  <!--===== TC11DeliveryDate                                                          -->
   <!--================================================================================-->
   <xs:simpleType name="TC11DeliveryDateContentType">
     <xs:annotation>
@@ -2702,7 +2718,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Text                                                                            -->
+  <!--===== Text                                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="TextContentType01">
     <xs:annotation>
@@ -2721,7 +2737,7 @@
     <xs:restriction base="AlphaNumeric_MAX512_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== TIRCarnet                                                                       -->
+  <!--===== TIRCarnet                                                                 -->
   <!--================================================================================-->
   <xs:simpleType name="TIRCarnetContentType">
     <xs:annotation>
@@ -2734,7 +2750,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== TIRCarnetNumber                                                                 -->
+  <!--===== TIRCarnetNumber                                                           -->
   <!--================================================================================-->
   <xs:simpleType name="TIRCarnetNumberContentType">
     <xs:annotation>
@@ -2745,7 +2761,7 @@
     <xs:restriction base="TIRcarnetNumber" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== TIRHolderIdentificationNumber                                                   -->
+  <!--===== TIRHolderIdentificationNumber                                             -->
   <!--================================================================================-->
   <xs:simpleType name="TIRHolderIdentificationNumberContentType01">
     <xs:annotation>
@@ -2764,7 +2780,7 @@
     <xs:restriction base="AlphaNumeric_MAX17_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== TransitDeclarationGoodsItemNumber                                               -->
+  <!--===== TransitDeclarationGoodsItemNumber                                         -->
   <!--================================================================================-->
   <xs:simpleType name="TransitDeclarationGoodsItemNumberContentType">
     <xs:annotation>
@@ -2775,7 +2791,7 @@
     <xs:restriction base="NCTS-P5_DeclarationGoodsItemNumberType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== TransitProcedureCategory                                                        -->
+  <!--===== TransitProcedureCategory                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="TransitProcedureCategoryContentType">
     <xs:annotation>
@@ -2788,7 +2804,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Type                                                                            -->
+  <!--===== Type                                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="TypeContentType01">
     <xs:annotation>
@@ -2829,7 +2845,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== TypeOfIdentification                                                            -->
+  <!--===== TypeOfIdentification                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="TypeOfIdentificationContentType">
     <xs:annotation>
@@ -2842,7 +2858,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== TypeOfLocation                                                                  -->
+  <!--===== TypeOfLocation                                                            -->
   <!--================================================================================-->
   <xs:simpleType name="TypeOfLocationContentType">
     <xs:annotation>
@@ -2855,7 +2871,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== TypeOfPackages                                                                  -->
+  <!--===== TypeOfPackages                                                            -->
   <!--================================================================================-->
   <xs:simpleType name="TypeOfPackagesContentType">
     <xs:annotation>
@@ -2868,7 +2884,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== UnloadingCompletion                                                             -->
+  <!--===== UnloadingCompletion                                                       -->
   <!--================================================================================-->
   <xs:simpleType name="UnloadingCompletionContentType">
     <xs:annotation>
@@ -2881,7 +2897,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== UnloadingDate                                                                   -->
+  <!--===== UnloadingDate                                                             -->
   <!--================================================================================-->
   <xs:simpleType name="UnloadingDateContentType">
     <xs:annotation>
@@ -2892,7 +2908,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== UnloadingRemark                                                                 -->
+  <!--===== UnloadingRemark                                                           -->
   <!--================================================================================-->
   <xs:simpleType name="UnloadingRemarkContentType">
     <xs:annotation>
@@ -2903,7 +2919,7 @@
     <xs:restriction base="AlphaNumeric_MAX512_NoSpaces" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== UNLocode                                                                        -->
+  <!--===== UNLocode                                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="UNLocodeContentType">
     <xs:annotation>
@@ -2916,7 +2932,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== UNNumber                                                                        -->
+  <!--===== UNNumber                                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="UNNumberContentType">
     <xs:annotation>
@@ -2929,7 +2945,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== UsageCancellationDate                                                           -->
+  <!--===== UsageCancellationDate                                                     -->
   <!--================================================================================-->
   <xs:simpleType name="UsageCancellationDateContentType">
     <xs:annotation>
@@ -2940,7 +2956,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ValidityDate                                                                    -->
+  <!--===== ValidityDate                                                              -->
   <!--================================================================================-->
   <xs:simpleType name="ValidityDateContentType">
     <xs:annotation>
@@ -2951,7 +2967,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ValidityEndDate                                                                 -->
+  <!--===== ValidityEndDate                                                           -->
   <!--================================================================================-->
   <xs:simpleType name="ValidityEndDateContentType">
     <xs:annotation>
@@ -2962,7 +2978,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ValidityStartDate                                                               -->
+  <!--===== ValidityStartDate                                                         -->
   <!--================================================================================-->
   <xs:simpleType name="ValidityStartDateContentType">
     <xs:annotation>
@@ -2973,7 +2989,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== VoucherAmount                                                                   -->
+  <!--===== VoucherAmount                                                             -->
   <!--================================================================================-->
   <xs:simpleType name="VoucherAmountContentType">
     <xs:annotation>
@@ -2984,7 +3000,7 @@
     <xs:restriction base="DecimalWithZero_16_2" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== WarningCode                                                                     -->
+  <!--===== WarningCode                                                               -->
   <!--================================================================================-->
   <xs:simpleType name="WarningCodeContentType">
     <xs:annotation>
@@ -2997,7 +3013,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== WarningPointer                                                                  -->
+  <!--===== WarningPointer                                                            -->
   <!--================================================================================-->
   <xs:simpleType name="WarningPointerContentType">
     <xs:annotation>
@@ -3008,7 +3024,7 @@
     <xs:restriction base="AlphaNumeric_MAX512" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== WriteOffDate                                                                    -->
+  <!--===== WriteOffDate                                                              -->
   <!--================================================================================-->
   <xs:simpleType name="WriteOffDateContentType">
     <xs:annotation>
@@ -3019,7 +3035,7 @@
     <xs:restriction base="DateType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Year                                                                            -->
+  <!--===== Year                                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="YearContentType">
     <xs:annotation>
@@ -3030,10 +3046,10 @@
     <xs:restriction base="YearType" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Base Types                                                                      -->
+  <!--===== Base Types                                                                -->
   <!--================================================================================-->
   <!--================================================================================-->
-  <!--===== AES-P1_DeclarationGoodsItemNumberType                                           -->
+  <!--===== AES-P1_DeclarationGoodsItemNumberType                                     -->
   <!--================================================================================-->
   <xs:simpleType name="AES-P1_DeclarationGoodsItemNumberType">
     <xs:restriction base="xs:integer">
@@ -3043,7 +3059,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AES-P1_MRNType                                                                  -->
+  <!--===== AES-P1_MRNType                                                            -->
   <!--================================================================================-->
   <xs:simpleType name="AES-P1_MRNType">
     <xs:annotation>
@@ -3079,7 +3095,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alpha_1                                                                         -->
+  <!--===== Alpha_1                                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="Alpha_1">
     <xs:restriction base="AlphaType">
@@ -3088,7 +3104,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alpha_2                                                                         -->
+  <!--===== Alpha_2                                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="Alpha_2">
     <xs:restriction base="AlphaType">
@@ -3097,7 +3113,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alpha_3                                                                         -->
+  <!--===== Alpha_3                                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="Alpha_3">
     <xs:restriction base="AlphaType">
@@ -3106,7 +3122,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alpha_4                                                                         -->
+  <!--===== Alpha_4                                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="Alpha_4">
     <xs:restriction base="AlphaType">
@@ -3115,7 +3131,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alpha_Max8                                                                      -->
+  <!--===== Alpha_Max8                                                                -->
   <!--================================================================================-->
   <xs:simpleType name="Alpha_Max8">
     <xs:restriction base="AlphaType">
@@ -3124,7 +3140,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphaCapital1Type                                                               -->
+  <!--===== AlphaCapital1Type                                                         -->
   <!--================================================================================-->
   <xs:simpleType name="AlphaCapital1Type">
     <xs:restriction base="AlphaCapitalType">
@@ -3132,7 +3148,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphaCapital2Type                                                               -->
+  <!--===== AlphaCapital2Type                                                         -->
   <!--================================================================================-->
   <xs:simpleType name="AlphaCapital2Type">
     <xs:restriction base="AlphaCapitalType">
@@ -3140,7 +3156,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphaCapital3Type                                                               -->
+  <!--===== AlphaCapital3Type                                                         -->
   <!--================================================================================-->
   <xs:simpleType name="AlphaCapital3Type">
     <xs:restriction base="AlphaCapitalType">
@@ -3148,7 +3164,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphaCapital4Type                                                               -->
+  <!--===== AlphaCapital4Type                                                         -->
   <!--================================================================================-->
   <xs:simpleType name="AlphaCapital4Type">
     <xs:restriction base="AlphaCapitalType">
@@ -3156,7 +3172,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphaCapitalMax3Type                                                            -->
+  <!--===== AlphaCapitalMax3Type                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="AlphaCapitalMax3Type">
     <xs:restriction base="AlphaCapitalType">
@@ -3164,7 +3180,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphaCapitalType                                                                -->
+  <!--===== AlphaCapitalType                                                          -->
   <!--================================================================================-->
   <xs:simpleType name="AlphaCapitalType">
     <xs:restriction base="AlphaType">
@@ -3172,7 +3188,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_1                                                                  -->
+  <!--===== Alphanumeric_1                                                            -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_1">
     <xs:restriction base="AlphaNumType">
@@ -3181,7 +3197,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_2                                                                  -->
+  <!--===== Alphanumeric_2                                                            -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_2">
     <xs:restriction base="AlphaNumType">
@@ -3190,7 +3206,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphaNumeric_2_NoSpaces                                                         -->
+  <!--===== AlphaNumeric_2_NoSpaces                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="AlphaNumeric_2_NoSpaces">
     <xs:restriction base="AlphaNumType">
@@ -3199,7 +3215,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_3                                                                  -->
+  <!--===== Alphanumeric_3                                                            -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_3">
     <xs:restriction base="AlphaNumType">
@@ -3208,7 +3224,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_4                                                                  -->
+  <!--===== Alphanumeric_4                                                            -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_4">
     <xs:restriction base="AlphaNumType">
@@ -3217,7 +3233,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphaNumeric_4_NoSpaces                                                         -->
+  <!--===== AlphaNumeric_4_NoSpaces                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="AlphaNumeric_4_NoSpaces">
     <xs:restriction base="AlphaNumType">
@@ -3226,7 +3242,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_5                                                                  -->
+  <!--===== Alphanumeric_5                                                            -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_5">
     <xs:restriction base="AlphaNumType">
@@ -3235,7 +3251,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_8                                                                  -->
+  <!--===== Alphanumeric_8                                                            -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_8">
     <xs:restriction base="AlphaNumType">
@@ -3244,7 +3260,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_Capital_5                                                          -->
+  <!--===== Alphanumeric_Capital_5                                                    -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_Capital_5">
     <xs:restriction base="AlphanumericCapitalType">
@@ -3252,7 +3268,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphaNumeric_MAX12                                                              -->
+  <!--===== AlphaNumeric_MAX12                                                        -->
   <!--================================================================================-->
   <xs:simpleType name="AlphaNumeric_MAX12">
     <xs:restriction base="AlphaNumType">
@@ -3261,7 +3277,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphaNumeric_MAX12_NoSpaces                                                     -->
+  <!--===== AlphaNumeric_MAX12_NoSpaces                                               -->
   <!--================================================================================-->
   <xs:simpleType name="AlphaNumeric_MAX12_NoSpaces">
     <xs:restriction base="AlphaNumType">
@@ -3270,7 +3286,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_Max14                                                              -->
+  <!--===== Alphanumeric_Max14                                                        -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_Max14">
     <xs:restriction base="AlphaNumType">
@@ -3279,7 +3295,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_Max140                                                             -->
+  <!--===== Alphanumeric_Max140                                                       -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_Max140">
     <xs:restriction base="AlphaNumType">
@@ -3288,7 +3304,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_Max15                                                              -->
+  <!--===== Alphanumeric_Max15                                                        -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_Max15">
     <xs:restriction base="AlphaNumType">
@@ -3297,7 +3313,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_Max17                                                              -->
+  <!--===== Alphanumeric_Max17                                                        -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_Max17">
     <xs:restriction base="AlphaNumType">
@@ -3306,7 +3322,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_Max175                                                             -->
+  <!--===== Alphanumeric_Max175                                                       -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_Max175">
     <xs:restriction base="AlphaNumType">
@@ -3315,7 +3331,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphaNumeric_MAX17_NoSpaces                                                     -->
+  <!--===== AlphaNumeric_MAX17_NoSpaces                                               -->
   <!--================================================================================-->
   <xs:simpleType name="AlphaNumeric_MAX17_NoSpaces">
     <xs:restriction base="AlphaNumType">
@@ -3324,7 +3340,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_Max2                                                               -->
+  <!--===== Alphanumeric_Max2                                                         -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_Max2">
     <xs:restriction base="AlphaNumType">
@@ -3333,7 +3349,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_Max20                                                              -->
+  <!--===== Alphanumeric_Max20                                                        -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_Max20">
     <xs:restriction base="AlphaNumType">
@@ -3342,7 +3358,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphaNumeric_MAX20_NoSpaces                                                     -->
+  <!--===== AlphaNumeric_MAX20_NoSpaces                                               -->
   <!--================================================================================-->
   <xs:simpleType name="AlphaNumeric_MAX20_NoSpaces">
     <xs:restriction base="AlphaNumType">
@@ -3351,7 +3367,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_Max21                                                              -->
+  <!--===== Alphanumeric_Max21                                                        -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_Max21">
     <xs:restriction base="AlphaNumType">
@@ -3360,7 +3376,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_Max210                                                             -->
+  <!--===== Alphanumeric_Max210                                                       -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_Max210">
     <xs:restriction base="AlphaNumType">
@@ -3369,7 +3385,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_Max22                                                              -->
+  <!--===== Alphanumeric_Max22                                                        -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_Max22">
     <xs:restriction base="AlphaNumType">
@@ -3378,7 +3394,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphaNumeric_MAX22_NoSpaces                                                     -->
+  <!--===== AlphaNumeric_MAX22_NoSpaces                                               -->
   <!--================================================================================-->
   <xs:simpleType name="AlphaNumeric_MAX22_NoSpaces">
     <xs:restriction base="AlphaNumType">
@@ -3387,7 +3403,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphaNumeric_MAX256                                                             -->
+  <!--===== AlphaNumeric_MAX256                                                       -->
   <!--================================================================================-->
   <xs:simpleType name="AlphaNumeric_MAX256">
     <xs:restriction base="AlphaNumType">
@@ -3396,7 +3412,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphaNumeric_MAX256_NoSpaces                                                    -->
+  <!--===== AlphaNumeric_MAX256_NoSpaces                                              -->
   <!--================================================================================-->
   <xs:simpleType name="AlphaNumeric_MAX256_NoSpaces">
     <xs:restriction base="AlphaNumType">
@@ -3405,7 +3421,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_Max27                                                              -->
+  <!--===== Alphanumeric_Max27                                                        -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_Max27">
     <xs:restriction base="AlphaNumType">
@@ -3414,7 +3430,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_Max280                                                             -->
+  <!--===== Alphanumeric_Max280                                                       -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_Max280">
     <xs:restriction base="AlphaNumType">
@@ -3423,7 +3439,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_Max29                                                              -->
+  <!--===== Alphanumeric_Max29                                                        -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_Max29">
     <xs:restriction base="AlphaNumType">
@@ -3432,7 +3448,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_Max3                                                               -->
+  <!--===== Alphanumeric_Max3                                                         -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_Max3">
     <xs:restriction base="AlphaNumType">
@@ -3441,7 +3457,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_Max35                                                              -->
+  <!--===== Alphanumeric_Max35                                                        -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_Max35">
     <xs:restriction base="AlphaNumType">
@@ -3450,7 +3466,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_Max350                                                             -->
+  <!--===== Alphanumeric_Max350                                                       -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_Max350">
     <xs:restriction base="AlphaNumType">
@@ -3459,7 +3475,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphaNumeric_MAX35_NoSpaces                                                     -->
+  <!--===== AlphaNumeric_MAX35_NoSpaces                                               -->
   <!--================================================================================-->
   <xs:simpleType name="AlphaNumeric_MAX35_NoSpaces">
     <xs:restriction base="AlphaNumType">
@@ -3468,7 +3484,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_Max4                                                               -->
+  <!--===== Alphanumeric_Max4                                                         -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_Max4">
     <xs:restriction base="AlphaNumType">
@@ -3477,7 +3493,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_Max42                                                              -->
+  <!--===== Alphanumeric_Max42                                                        -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_Max42">
     <xs:restriction base="AlphaNumType">
@@ -3486,7 +3502,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphaNumeric_MAX4_NoSpaces                                                      -->
+  <!--===== AlphaNumeric_MAX4_NoSpaces                                                -->
   <!--================================================================================-->
   <xs:simpleType name="AlphaNumeric_MAX4_NoSpaces">
     <xs:restriction base="AlphaNumType">
@@ -3495,7 +3511,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_Max5                                                               -->
+  <!--===== Alphanumeric_Max5                                                         -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_Max5">
     <xs:restriction base="AlphaNumType">
@@ -3504,7 +3520,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphaNumeric_MAX512                                                             -->
+  <!--===== AlphaNumeric_MAX512                                                       -->
   <!--================================================================================-->
   <xs:simpleType name="AlphaNumeric_MAX512">
     <xs:restriction base="AlphaNumType">
@@ -3513,7 +3529,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphaNumeric_MAX512_NoSpaces                                                    -->
+  <!--===== AlphaNumeric_MAX512_NoSpaces                                              -->
   <!--================================================================================-->
   <xs:simpleType name="AlphaNumeric_MAX512_NoSpaces">
     <xs:restriction base="AlphaNumType">
@@ -3522,7 +3538,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_Max6                                                               -->
+  <!--===== Alphanumeric_Max6                                                         -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_Max6">
     <xs:restriction base="AlphaNumType">
@@ -3531,7 +3547,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphaNumeric_MAX7                                                               -->
+  <!--===== AlphaNumeric_MAX7                                                         -->
   <!--================================================================================-->
   <xs:simpleType name="AlphaNumeric_MAX7">
     <xs:restriction base="AlphaNumType">
@@ -3540,7 +3556,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_Max70                                                              -->
+  <!--===== Alphanumeric_Max70                                                        -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_Max70">
     <xs:restriction base="AlphaNumType">
@@ -3549,7 +3565,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphaNumeric_MAX70_NoSpaces                                                     -->
+  <!--===== AlphaNumeric_MAX70_NoSpaces                                               -->
   <!--================================================================================-->
   <xs:simpleType name="AlphaNumeric_MAX70_NoSpaces">
     <xs:restriction base="AlphaNumType">
@@ -3558,7 +3574,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Alphanumeric_Max8                                                               -->
+  <!--===== Alphanumeric_Max8                                                         -->
   <!--================================================================================-->
   <xs:simpleType name="Alphanumeric_Max8">
     <xs:restriction base="AlphaNumType">
@@ -3567,7 +3583,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphanumericCapital1Type                                                        -->
+  <!--===== AlphanumericCapital1Type                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="AlphanumericCapital1Type">
     <xs:restriction base="AlphanumericCapitalType">
@@ -3575,7 +3591,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphanumericCapital2Type                                                        -->
+  <!--===== AlphanumericCapital2Type                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="AlphanumericCapital2Type">
     <xs:restriction base="AlphanumericCapitalType">
@@ -3583,7 +3599,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphanumericCapital3Type                                                        -->
+  <!--===== AlphanumericCapital3Type                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="AlphanumericCapital3Type">
     <xs:restriction base="AlphanumericCapitalType">
@@ -3591,7 +3607,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphanumericCapital5Type                                                        -->
+  <!--===== AlphanumericCapital5Type                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="AlphanumericCapital5Type">
     <xs:restriction base="AlphanumericCapitalType">
@@ -3599,7 +3615,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphanumericCapitalMax2Type                                                     -->
+  <!--===== AlphanumericCapitalMax2Type                                               -->
   <!--================================================================================-->
   <xs:simpleType name="AlphanumericCapitalMax2Type">
     <xs:restriction base="AlphanumericCapitalType">
@@ -3607,7 +3623,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphanumericCapitalMax3Type                                                     -->
+  <!--===== AlphanumericCapitalMax3Type                                               -->
   <!--================================================================================-->
   <xs:simpleType name="AlphanumericCapitalMax3Type">
     <xs:restriction base="AlphanumericCapitalType">
@@ -3615,7 +3631,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphanumericCapitalMax4Type                                                     -->
+  <!--===== AlphanumericCapitalMax4Type                                               -->
   <!--================================================================================-->
   <xs:simpleType name="AlphanumericCapitalMax4Type">
     <xs:restriction base="AlphanumericCapitalType">
@@ -3623,7 +3639,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphanumericCapitalMax5Type                                                     -->
+  <!--===== AlphanumericCapitalMax5Type                                               -->
   <!--================================================================================-->
   <xs:simpleType name="AlphanumericCapitalMax5Type">
     <xs:restriction base="AlphanumericCapitalType">
@@ -3631,7 +3647,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphanumericCapitalMax6Type                                                     -->
+  <!--===== AlphanumericCapitalMax6Type                                               -->
   <!--================================================================================-->
   <xs:simpleType name="AlphanumericCapitalMax6Type">
     <xs:restriction base="AlphanumericCapitalType">
@@ -3639,7 +3655,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphanumericCapitalMax9Type                                                     -->
+  <!--===== AlphanumericCapitalMax9Type                                               -->
   <!--================================================================================-->
   <xs:simpleType name="AlphanumericCapitalMax9Type">
     <xs:restriction base="AlphanumericCapitalType">
@@ -3647,7 +3663,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphanumericCapitalType                                                         -->
+  <!--===== AlphanumericCapitalType                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="AlphanumericCapitalType">
     <xs:restriction base="AlphaNumType">
@@ -3655,7 +3671,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphanumericCapitalTypeOfDeclaration                                            -->
+  <!--===== AlphanumericCapitalTypeOfDeclaration                                      -->
   <!--================================================================================-->
   <xs:simpleType name="AlphanumericCapitalTypeOfDeclaration">
     <xs:restriction base="AlphanumericCapitalMax9Type">
@@ -3663,7 +3679,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphanumericSpecMax35Type                                                       -->
+  <!--===== AlphanumericSpecMax35Type                                                 -->
   <!--================================================================================-->
   <xs:simpleType name="AlphanumericSpecMax35Type">
     <xs:restriction base="AlphaNumType">
@@ -3672,7 +3688,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphaNumType                                                                    -->
+  <!--===== AlphaNumType                                                              -->
   <!--================================================================================-->
   <xs:simpleType name="AlphaNumType">
     <xs:annotation>
@@ -3681,7 +3697,7 @@
     <xs:restriction base="xs:normalizedString" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AlphaType                                                                       -->
+  <!--===== AlphaType                                                                 -->
   <!--================================================================================-->
   <xs:simpleType name="AlphaType">
     <xs:annotation>
@@ -3691,7 +3707,7 @@
     <xs:restriction base="xs:normalizedString" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== CityType                                                                        -->
+  <!--===== CityType                                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="CityType">
     <xs:annotation>
@@ -3704,7 +3720,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ContainerIdentificationNumber                                                   -->
+  <!--===== ContainerIdentificationNumber                                             -->
   <!--================================================================================-->
   <xs:simpleType name="ContainerIdentificationNumber">
     <xs:annotation>
@@ -3717,7 +3733,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ContainerIdentificationNumber_NoSpaces                                          -->
+  <!--===== ContainerIdentificationNumber_NoSpaces                                    -->
   <!--================================================================================-->
   <xs:simpleType name="ContainerIdentificationNumber_NoSpaces">
     <xs:restriction base="AlphaNumType">
@@ -3727,7 +3743,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ConveyanceReferenceNumber17                                                     -->
+  <!--===== ConveyanceReferenceNumber17                                               -->
   <!--================================================================================-->
   <xs:simpleType name="ConveyanceReferenceNumber17">
     <xs:annotation>
@@ -3740,7 +3756,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ConveyanceReferenceNumber17_NoSpaces                                            -->
+  <!--===== ConveyanceReferenceNumber17_NoSpaces                                      -->
   <!--================================================================================-->
   <xs:simpleType name="ConveyanceReferenceNumber17_NoSpaces">
     <xs:restriction base="AlphaNumType">
@@ -3750,7 +3766,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== ConveyanceReferenceNumber35                                                     -->
+  <!--===== ConveyanceReferenceNumber35                                               -->
   <!--================================================================================-->
   <xs:simpleType name="ConveyanceReferenceNumber35">
     <xs:annotation>
@@ -3763,7 +3779,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== CORefNumType                                                                    -->
+  <!--===== CORefNumType                                                              -->
   <!--================================================================================-->
   <xs:simpleType name="CORefNumType">
     <xs:annotation>
@@ -3776,7 +3792,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== CountryCodeType                                                                 -->
+  <!--===== CountryCodeType                                                           -->
   <!--================================================================================-->
   <xs:simpleType name="CountryCodeType">
     <xs:annotation>
@@ -3788,31 +3804,44 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== DateTimeType                                                                    -->
+  <!--===== DateTimeType                                                              -->
   <!--================================================================================-->
   <xs:simpleType name="DateTimeType">
     <xs:annotation>
       <xs:documentation>The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:dateTime">
-      <xs:pattern value="\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}" />
+      <xs:pattern value="\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?" />
     </xs:restriction>
     <!-- Updated -->
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== DateType                                                                        -->
+  <!--===== DateType                                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="DateType">
     <xs:annotation>
       <xs:documentation>Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:date">
-      <xs:pattern value="\d{4}-\d{2}-\d{2}" />
+      <xs:pattern value="\d{4}-\d{2}-\d{2}(\.\d+)?" />
     </xs:restriction>
     <!-- Updated -->
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Decimal_11_3                                                                    -->
+  <!--===== DayInTheMonthType                                                         -->
+  <!--================================================================================-->
+  <xs:simpleType name="DayInTheMonthType">
+    <xs:annotation>
+      <xs:documentation>Day in the Month (format:
+				DD)</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="NumType">
+      <xs:length value="2" />
+      <xs:pattern value="[0][1-9]|[1-2][0-9]|[3][0-1]" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!--================================================================================-->
+  <!--===== Decimal_11_3                                                              -->
   <!--================================================================================-->
   <xs:simpleType name="Decimal_11_3">
     <xs:restriction base="DecType">
@@ -3821,7 +3850,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Decimal_15_2                                                                    -->
+  <!--===== Decimal_15_2                                                              -->
   <!--================================================================================-->
   <xs:simpleType name="Decimal_15_2">
     <xs:restriction base="DecType">
@@ -3830,7 +3859,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Decimal_6_5                                                                     -->
+  <!--===== Decimal_6_5                                                               -->
   <!--================================================================================-->
   <xs:simpleType name="Decimal_6_5">
     <xs:restriction base="DecType">
@@ -3839,7 +3868,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Decimal_8_6                                                                     -->
+  <!--===== Decimal_8_6                                                               -->
   <!--================================================================================-->
   <xs:simpleType name="Decimal_8_6">
     <xs:restriction base="DecType">
@@ -3848,7 +3877,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== DecimalWithoutZero_16_2                                                         -->
+  <!--===== DecimalWithoutZero_16_2                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="DecimalWithoutZero_16_2">
     <xs:restriction base="xs:decimal">
@@ -3859,7 +3888,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== DecimalWithoutZero_16_6                                                         -->
+  <!--===== DecimalWithoutZero_16_6                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="DecimalWithoutZero_16_6">
     <xs:restriction base="xs:decimal">
@@ -3870,7 +3899,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== DecimalWithZero_16_2                                                            -->
+  <!--===== DecimalWithZero_16_2                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="DecimalWithZero_16_2">
     <xs:restriction base="xs:decimal">
@@ -3880,7 +3909,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== DecimalWithZero_16_6                                                            -->
+  <!--===== DecimalWithZero_16_6                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="DecimalWithZero_16_6">
     <xs:restriction base="xs:decimal">
@@ -3890,7 +3919,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== DeclarationGoodsItemNumberType                                                  -->
+  <!--===== DeclarationGoodsItemNumberType                                            -->
   <!--================================================================================-->
   <xs:simpleType name="DeclarationGoodsItemNumberType">
     <xs:restriction base="xs:integer">
@@ -3900,7 +3929,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== DeclarationGoodsItemNumberType_WithZero                                         -->
+  <!--===== DeclarationGoodsItemNumberType_WithZero                                   -->
   <!--================================================================================-->
   <xs:simpleType name="DeclarationGoodsItemNumberType_WithZero">
     <xs:restriction base="xs:integer">
@@ -3910,7 +3939,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== DecType                                                                         -->
+  <!--===== DecType                                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="DecType">
     <xs:annotation>
@@ -3919,7 +3948,7 @@
     <xs:restriction base="xs:decimal" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== emailAddressType                                                                -->
+  <!--===== emailAddressType                                                          -->
   <!--================================================================================-->
   <xs:simpleType name="emailAddressType">
     <xs:restriction base="StringLatin1">
@@ -3928,7 +3957,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== EmailAddressType256                                                             -->
+  <!--===== EmailAddressType256                                                       -->
   <!--================================================================================-->
   <xs:simpleType name="EmailAddressType256">
     <xs:restriction base="StringLatin1">
@@ -3937,7 +3966,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== EmailAddressType256_NoSpaces                                                    -->
+  <!--===== EmailAddressType256_NoSpaces                                              -->
   <!--================================================================================-->
   <xs:simpleType name="EmailAddressType256_NoSpaces">
     <xs:restriction base="StringLatin1">
@@ -3946,7 +3975,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== GNSSLatitude                                                                    -->
+  <!--===== GNSSLatitude                                                              -->
   <!--================================================================================-->
   <xs:simpleType name="GNSSLatitude">
     <xs:annotation>
@@ -3957,7 +3986,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== GNSSLongitude                                                                   -->
+  <!--===== GNSSLongitude                                                             -->
   <!--================================================================================-->
   <xs:simpleType name="GNSSLongitude">
     <xs:annotation>
@@ -3968,7 +3997,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== GRNType                                                                         -->
+  <!--===== GRNType                                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="GRNType">
     <xs:annotation>
@@ -3979,7 +4008,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== IdentificationNumber35                                                          -->
+  <!--===== IdentificationNumber35                                                    -->
   <!--================================================================================-->
   <xs:simpleType name="IdentificationNumber35">
     <xs:annotation>
@@ -3992,7 +4021,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== LanguageCodeType                                                                -->
+  <!--===== LanguageCodeType                                                          -->
   <!--================================================================================-->
   <xs:simpleType name="LanguageCodeType">
     <xs:annotation>
@@ -4000,11 +4029,11 @@
     </xs:annotation>
     <xs:restriction base="AlphaType">
       <xs:length value="2" />
-      <xs:pattern value="[A-Za-z]{2}" />
+      <xs:pattern value="[A-Z]{2}" />
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== MRNType                                                                         -->
+  <!--===== MRNType                                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="MRNType">
     <xs:annotation>
@@ -4039,7 +4068,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== NCTS-P5_DeclarationGoodsItemNumberType                                          -->
+  <!--===== NCTS-P5_DeclarationGoodsItemNumberType                                    -->
   <!--================================================================================-->
   <xs:simpleType name="NCTS-P5_DeclarationGoodsItemNumberType">
     <xs:restriction base="xs:integer">
@@ -4049,7 +4078,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== NCTS-P5_MRNType                                                                 -->
+  <!--===== NCTS-P5_MRNType                                                           -->
   <!--================================================================================-->
   <xs:simpleType name="NCTS-P5_MRNType">
     <xs:annotation>
@@ -4084,7 +4113,185 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== NumericWithoutZero_1                                                            -->
+  <!--===== Numeric2                                                                  -->
+  <!--================================================================================-->
+  <xs:simpleType name="Numeric2">
+    <xs:restriction base="NumType">
+      <xs:length value="2" />
+      <xs:pattern value="[0-9]{2}" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!--================================================================================-->
+  <!--===== Numeric2Max                                                               -->
+  <!--================================================================================-->
+  <xs:simpleType name="Numeric2Max">
+    <xs:restriction base="NumType">
+      <xs:maxLength value="8" />
+      <xs:pattern value="[0-9]{1,2}" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!--================================================================================-->
+  <!--===== Numeric3                                                                  -->
+  <!--================================================================================-->
+  <xs:simpleType name="Numeric3">
+    <xs:restriction base="NumType">
+      <xs:length value="3" />
+      <xs:pattern value="[0-9]{3}" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!--================================================================================-->
+  <!--===== Numeric4                                                                  -->
+  <!--================================================================================-->
+  <xs:simpleType name="Numeric4">
+    <xs:restriction base="NumType">
+      <xs:length value="4" />
+      <xs:pattern value="[0-9]{4}" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!--================================================================================-->
+  <!--===== Numeric6Max                                                               -->
+  <!--================================================================================-->
+  <xs:simpleType name="Numeric6Max">
+    <xs:restriction base="NumType">
+      <xs:maxLength value="8" />
+      <xs:pattern value="[0-9]{1,6}" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!--================================================================================-->
+  <!--===== Numeric8Max                                                               -->
+  <!--================================================================================-->
+  <xs:simpleType name="Numeric8Max">
+    <xs:restriction base="NumType">
+      <xs:maxLength value="8" />
+      <xs:pattern value="[0-9]{1,8}" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!--================================================================================-->
+  <!--===== Numeric_1                                                                 -->
+  <!--================================================================================-->
+  <xs:simpleType name="Numeric_1">
+    <xs:restriction base="NumType">
+      <xs:length value="1" />
+      <xs:pattern value="[0-9]" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!--================================================================================-->
+  <!--===== Numeric_2                                                                 -->
+  <!--================================================================================-->
+  <xs:simpleType name="Numeric_2">
+    <xs:restriction base="NumType">
+      <xs:length value="2" />
+      <xs:pattern value="[0-9]{2}" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!--================================================================================-->
+  <!--===== Numeric_3                                                                 -->
+  <!--================================================================================-->
+  <xs:simpleType name="Numeric_3">
+    <xs:restriction base="NumType">
+      <xs:length value="3" />
+      <xs:pattern value="[0-9]{3}" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!--================================================================================-->
+  <!--===== Numeric_4                                                                 -->
+  <!--================================================================================-->
+  <xs:simpleType name="Numeric_4">
+    <xs:restriction base="NumType">
+      <xs:length value="4" />
+      <xs:pattern value="[0-9]{4}" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!--================================================================================-->
+  <!--===== Numeric_Max11                                                             -->
+  <!--================================================================================-->
+  <xs:simpleType name="Numeric_Max11">
+    <xs:restriction base="NumType">
+      <xs:maxLength value="11" />
+      <xs:pattern value="[0-9]{1,11}" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!--================================================================================-->
+  <!--===== Numeric_Max2                                                              -->
+  <!--================================================================================-->
+  <xs:simpleType name="Numeric_Max2">
+    <xs:restriction base="NumType">
+      <xs:maxLength value="2" />
+      <xs:pattern value="[0-9]{1,2}" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!--================================================================================-->
+  <!--===== Numeric_Max3                                                              -->
+  <!--================================================================================-->
+  <xs:simpleType name="Numeric_Max3">
+    <xs:restriction base="NumType">
+      <xs:maxLength value="3" />
+      <xs:pattern value="[0-9]{1,3}" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!--================================================================================-->
+  <!--===== Numeric_Max4                                                              -->
+  <!--================================================================================-->
+  <xs:simpleType name="Numeric_Max4">
+    <xs:restriction base="NumType">
+      <xs:maxLength value="4" />
+      <xs:pattern value="[0-9]{1,4}" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!--================================================================================-->
+  <!--===== Numeric_Max5                                                              -->
+  <!--================================================================================-->
+  <xs:simpleType name="Numeric_Max5">
+    <xs:restriction base="NumType">
+      <xs:maxLength value="5" />
+      <xs:pattern value="[0-9]{1,5}" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!--================================================================================-->
+  <!--===== Numeric_Max6                                                              -->
+  <!--================================================================================-->
+  <xs:simpleType name="Numeric_Max6">
+    <xs:restriction base="NumType">
+      <xs:maxLength value="6" />
+      <xs:pattern value="[0-9]{1,6}" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!--================================================================================-->
+  <!--===== Numeric_Max7                                                              -->
+  <!--================================================================================-->
+  <xs:simpleType name="Numeric_Max7">
+    <xs:restriction base="NumType">
+      <xs:maxLength value="7" />
+      <xs:pattern value="[0-9]{1,7}" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!--================================================================================-->
+  <!--===== Numeric_Max9                                                              -->
+  <!--================================================================================-->
+  <xs:simpleType name="Numeric_Max9">
+    <xs:restriction base="NumType">
+      <xs:maxLength value="9" />
+      <xs:pattern value="[0-9]{1,9}" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!--================================================================================-->
+  <!--===== NumericMin4Max8                                                           -->
+  <!--================================================================================-->
+  <xs:simpleType name="NumericMin4Max8">
+    <xs:restriction base="NumType">
+      <xs:pattern value="[0-9]{4,8}" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!--================================================================================-->
+  <!--===== NumericMin4Max8Type                                                       -->
+  <!--================================================================================-->
+  <xs:simpleType name="NumericMin4Max8Type">
+    <xs:restriction base="NumType">
+      <xs:pattern value="[0-9]{4,8}" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!--================================================================================-->
+  <!--===== NumericWithoutZero_1                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="NumericWithoutZero_1">
     <xs:restriction base="xs:integer">
@@ -4094,7 +4301,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== NumericWithoutZero_3                                                            -->
+  <!--===== NumericWithoutZero_3                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="NumericWithoutZero_3">
     <xs:restriction base="xs:integer">
@@ -4104,7 +4311,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== NumericWithoutZero_5                                                            -->
+  <!--===== NumericWithoutZero_5                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="NumericWithoutZero_5">
     <xs:restriction base="xs:integer">
@@ -4114,7 +4321,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== NumericWithoutZero_8                                                            -->
+  <!--===== NumericWithoutZero_8                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="NumericWithoutZero_8">
     <xs:restriction base="xs:integer">
@@ -4124,47 +4331,47 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== NumericWithZero_3                                                               -->
+  <!--===== NumericWithZero_3                                                         -->
   <!--================================================================================-->
   <xs:simpleType name="NumericWithZero_3">
     <xs:restriction base="xs:integer">
       <xs:minInclusive value="0" />
       <xs:maxInclusive value="999" />
-      <xs:pattern value="(0|[1-9][0-9]{0,2})" />
+      <xs:pattern value="[0-9]{1,3}" />
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== NumericWithZero_4                                                               -->
+  <!--===== NumericWithZero_4                                                         -->
   <!--================================================================================-->
   <xs:simpleType name="NumericWithZero_4">
     <xs:restriction base="xs:integer">
       <xs:minInclusive value="0" />
       <xs:maxInclusive value="9999" />
-      <xs:pattern value="(0|[1-9][0-9]{0,3})" />
+      <xs:pattern value="[0-9]{1,4}" />
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== NumericWithZero_8                                                               -->
+  <!--===== NumericWithZero_8                                                         -->
   <!--================================================================================-->
   <xs:simpleType name="NumericWithZero_8">
     <xs:restriction base="xs:integer">
       <xs:minInclusive value="0" />
       <xs:maxInclusive value="99999999" />
-      <xs:pattern value="(0|[1-9][0-9]{0,7})" />
+      <xs:pattern value="[0-9]{1,8}" />
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== NumericWithZero_9                                                               -->
+  <!--===== NumericWithZero_9                                                         -->
   <!--================================================================================-->
   <xs:simpleType name="NumericWithZero_9">
     <xs:restriction base="xs:integer">
       <xs:minInclusive value="0" />
       <xs:maxInclusive value="999999999" />
-      <xs:pattern value="(0|[1-9][0-9]{0,8})" />
+      <xs:pattern value="[0-9]{1,9}" />
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== NumType                                                                         -->
+  <!--===== NumType                                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="NumType">
     <xs:annotation>
@@ -4174,7 +4381,7 @@
     <xs:restriction base="xs:token" />
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== phaseIDtype                                                                     -->
+  <!--===== phaseIDtype                                                               -->
   <!--================================================================================-->
   <xs:simpleType name="phaseIDtype">
     <xs:restriction base="xs:token">
@@ -4196,7 +4403,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== PostalCodeType                                                                  -->
+  <!--===== PostalCodeType                                                            -->
   <!--================================================================================-->
   <xs:simpleType name="PostalCodeType">
     <xs:annotation>
@@ -4209,7 +4416,7 @@
     <!-- Updated -->
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== RiskAnalysisResultCode                                                          -->
+  <!--===== RiskAnalysisResultCode                                                    -->
   <!--================================================================================-->
   <xs:simpleType name="RiskAnalysisResultCode">
     <xs:annotation>
@@ -4225,7 +4432,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== StreetNumType                                                                   -->
+  <!--===== StreetNumType                                                             -->
   <!--================================================================================-->
   <xs:simpleType name="StreetNumType">
     <xs:annotation>
@@ -4237,7 +4444,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== StringLatin1                                                                    -->
+  <!--===== StringLatin1                                                              -->
   <!--================================================================================-->
   <xs:simpleType name="StringLatin1">
     <xs:restriction base="xs:normalizedString">
@@ -4245,7 +4452,18 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== TINNewType                                                                      -->
+  <!--===== TimeType                                                                  -->
+  <!--================================================================================-->
+  <xs:simpleType name="TimeType">
+    <xs:annotation>
+      <xs:documentation>The time zone although not included UTC is implied</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:time">
+      <xs:pattern value="\d{2}:\d{2}:\d{2}(\.\d+)?" />
+    </xs:restriction>
+  </xs:simpleType>
+  <!--================================================================================-->
+  <!--===== TINNewType                                                                -->
   <!--================================================================================-->
   <xs:simpleType name="TINNewType">
     <xs:annotation>
@@ -4258,7 +4476,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== TINType                                                                         -->
+  <!--===== TINType                                                                   -->
   <!--================================================================================-->
   <xs:simpleType name="TINType">
     <xs:annotation>
@@ -4272,7 +4490,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== TINTypeRelaxed                                                                  -->
+  <!--===== TINTypeRelaxed                                                            -->
   <!--================================================================================-->
   <xs:simpleType name="TINTypeRelaxed">
     <xs:restriction base="AlphaNumType">
@@ -4281,7 +4499,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== TIRcarnetNumber                                                                 -->
+  <!--===== TIRcarnetNumber                                                           -->
   <!--================================================================================-->
   <xs:simpleType name="TIRcarnetNumber">
     <xs:annotation>
@@ -4294,7 +4512,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== TradNameType                                                                    -->
+  <!--===== TradNameType                                                              -->
   <!--================================================================================-->
   <xs:simpleType name="TradNameType">
     <xs:annotation>
@@ -4306,7 +4524,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== UCRReferenceNumber35                                                            -->
+  <!--===== UCRReferenceNumber35                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="UCRReferenceNumber35">
     <xs:annotation>
@@ -4319,7 +4537,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== UCRReferenceNumber35_NoSpaces                                                   -->
+  <!--===== UCRReferenceNumber35_NoSpaces                                             -->
   <!--================================================================================-->
   <xs:simpleType name="UCRReferenceNumber35_NoSpaces">
     <xs:restriction base="AlphaNumType">
@@ -4329,7 +4547,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== UCRReferenceNumber70                                                            -->
+  <!--===== UCRReferenceNumber70                                                      -->
   <!--================================================================================-->
   <xs:simpleType name="UCRReferenceNumber70">
     <xs:annotation>
@@ -4342,7 +4560,7 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== YearType                                                                        -->
+  <!--===== YearType                                                                  -->
   <!--================================================================================-->
   <xs:simpleType name="YearType">
     <xs:annotation>

--- a/conf/xsd/tcl.xsd
+++ b/conf/xsd/tcl.xsd
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ncts.dgtaxud.ec" xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" targetNamespace="http://ncts.dgtaxud.ec" elementFormDefault="unqualified" attributeFormDefault="unqualified" version="51.8.6" vc:minVersion="1.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ncts.dgtaxud.ec" xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" targetNamespace="http://ncts.dgtaxud.ec" elementFormDefault="unqualified" attributeFormDefault="unqualified" version="51.8.0" vc:minVersion="1.1">
   <!--================================================================================-->
-  <!--===== Modification Type                                                               -->
-  <!--===== Format: a1                                                                      -->
-  <!--===== CL024                                                                           -->
+  <!--===== Modification Type                                                         -->
+  <!--===== Format: a1                                                                -->
+  <!--===== CL024                                                                     -->
   <!--================================================================================-->
   <xs:simpleType name="ModificationType">
     <xs:annotation>
@@ -28,9 +28,9 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Month of Year                                                                   -->
-  <!--===== Format: an2                                                                     -->
-  <!--===== CL026                                                                           -->
+  <!--===== Month of Year                                                             -->
+  <!--===== Format: an2                                                               -->
+  <!--===== CL026                                                                     -->
   <!--================================================================================-->
   <xs:simpleType name="MonthOfYear">
     <xs:annotation>
@@ -100,9 +100,9 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Flag                                                                            -->
-  <!--===== Format: n1                                                                      -->
-  <!--===== CL027                                                                           -->
+  <!--===== Flag                                                                      -->
+  <!--===== Format: n1                                                                -->
+  <!--===== CL027                                                                     -->
   <!--================================================================================-->
   <xs:simpleType name="Flag">
     <xs:annotation>
@@ -122,9 +122,9 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== XML Error Codes                                                                 -->
-  <!--===== Format: n2                                                                      -->
-  <!--===== CL030                                                                           -->
+  <!--===== XML Error Codes                                                           -->
+  <!--===== Format: n2                                                                -->
+  <!--===== CL030                                                                     -->
   <!--================================================================================-->
   <xs:simpleType name="XmlErrorCodes">
     <xs:annotation>
@@ -209,9 +209,9 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Message Types                                                                   -->
-  <!--===== Format: an..6                                                                   -->
-  <!--===== CL060                                                                           -->
+  <!--===== Message Types                                                             -->
+  <!--===== Format: an..6                                                             -->
+  <!--===== CL060                                                                     -->
   <!--================================================================================-->
   <xs:simpleType name="MessageTypes">
     <xs:annotation>
@@ -676,9 +676,9 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== Country Codes (Customs Office Lists)                                            -->
-  <!--===== Format: a2                                                                      -->
-  <!--===== CL070                                                                           -->
+  <!--===== Country Codes (Customs Office Lists)                                      -->
+  <!--===== Format: a2                                                                -->
+  <!--===== CL070                                                                     -->
   <!--================================================================================-->
   <xs:simpleType name="CountryCodesCustomsOfficeLists">
     <xs:annotation>
@@ -865,11 +865,6 @@
           <xs:documentation>Turkey</xs:documentation>
         </xs:annotation>
       </xs:enumeration>
-      <xs:enumeration value="UA">
-        <xs:annotation>
-          <xs:documentation>Ukraine</xs:documentation>
-        </xs:annotation>
-      </xs:enumeration>
       <xs:enumeration value="XI">
         <xs:annotation>
           <xs:documentation>United Kingdom (Northern Ireland)</xs:documentation>
@@ -878,9 +873,9 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== System Unavailability Type                                                      -->
-  <!--===== Format: a1                                                                      -->
-  <!--===== CL079                                                                           -->
+  <!--===== System Unavailability Type                                                -->
+  <!--===== Format: a1                                                                -->
+  <!--===== CL079                                                                     -->
   <!--================================================================================-->
   <xs:simpleType name="SystemUnavailabilityType">
     <xs:annotation>
@@ -905,9 +900,9 @@
     </xs:restriction>
   </xs:simpleType>
   <!--================================================================================-->
-  <!--===== AES/NCTS P5 Functional Error Codes                                              -->
-  <!--===== Format: n2                                                                      -->
-  <!--===== CL180                                                                           -->
+  <!--===== AES/NCTS P5 Functional Error Codes                                        -->
+  <!--===== Format: n2                                                                -->
+  <!--===== CL180                                                                     -->
   <!--================================================================================-->
   <xs:simpleType name="AesNctsP5FunctionalErrorCodes">
     <xs:annotation>

--- a/it/test/repositories/SessionRepositorySpec.scala
+++ b/it/test/repositories/SessionRepositorySpec.scala
@@ -17,7 +17,7 @@
 package repositories
 
 import config.FrontendAppConfig
-import generated.{CC043C, CC043CType, CustomsOfficeOfDestinationActualType03, MESSAGESequence, Number0, TraderAtDestinationType03, TransitOperationType14}
+import generated._
 import itbase.ItSpecBase
 import models.{ArrivalId, EoriNumber, MovementReferenceNumber, SensitiveFormats, UserAnswers}
 import play.api.libs.json.Json
@@ -39,11 +39,17 @@ class SessionRepositorySpec extends ItSpecBase with DefaultPlayMongoRepositorySu
   private val ie043: CC043CType = CC043CType(
     messageSequence1 = MESSAGESequence(
       messageSender = "",
-      messageRecipient = "",
-      preparationDateAndTime = XMLCalendar("2022-02-03T08:45:00.000000"),
-      messageIdentification = "",
-      messageType = CC043C,
-      correlationIdentifier = None
+      messagE_1Sequence2 = MESSAGE_1Sequence(
+        messageRecipient = "",
+        preparationDateAndTime = XMLCalendar("2022-02-03T08:45:00.000000"),
+        messageIdentification = ""
+      ),
+      messagE_TYPESequence3 = MESSAGE_TYPESequence(
+        messageType = CC043C
+      ),
+      correlatioN_IDENTIFIERSequence4 = CORRELATION_IDENTIFIERSequence(
+        correlationIdentifier = None
+      )
     ),
     TransitOperation = TransitOperationType14(
       MRN = "MRN",

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -100,8 +100,8 @@ trait SpecBase
     def removeValue(page: QuestionPage[_]): UserAnswers =
       userAnswers.remove(page).success.value
 
-    def getSequenceNumber(section: Section[JsObject]): BigInt =
-      getValue[JsNumber](section, SequenceNumber).value.toBigInt
+    def getSequenceNumber(section: Section[JsObject]): String =
+      getValue[JsNumber](section, SequenceNumber).value.toBigInt.toString()
 
     def getValue[A <: JsValue](section: Section[JsObject], key: String)(implicit reads: Reads[A]): A =
       userAnswers.data.transform((section.path \ key).json.pick[A]).get

--- a/test/base/TestMessageData.scala
+++ b/test/base/TestMessageData.scala
@@ -24,11 +24,17 @@ trait TestMessageData {
   val basicIe043: CC043CType = CC043CType(
     messageSequence1 = MESSAGESequence(
       messageSender = "",
-      messageRecipient = "",
-      preparationDateAndTime = XMLCalendar("2022-02-03T08:45:00.000000"),
-      messageIdentification = "",
-      messageType = CC043C,
-      correlationIdentifier = None
+      messagE_1Sequence2 = MESSAGE_1Sequence(
+        messageRecipient = "",
+        preparationDateAndTime = XMLCalendar("2022-02-03T08:45:00.000000"),
+        messageIdentification = ""
+      ),
+      messagE_TYPESequence3 = MESSAGE_TYPESequence(
+        messageType = CC043C
+      ),
+      correlatioN_IDENTIFIERSequence4 = CORRELATION_IDENTIFIERSequence(
+        correlationIdentifier = None
+      )
     ),
     TransitOperation = TransitOperationType14(
       MRN = "MRN",

--- a/test/controllers/houseConsignment/index/items/RemoveConsignmentItemYesNoControllerSpec.scala
+++ b/test/controllers/houseConsignment/index/items/RemoveConsignmentItemYesNoControllerSpec.scala
@@ -25,10 +25,9 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, when}
 import pages.houseConsignment.index.items.DeclarationGoodsItemNumberPage
 import pages.sections.ItemSection
-import play.api.libs.json.{__, Json}
+import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import utils.transformers.SequenceNumber
 import views.html.houseConsignment.index.items.RemoveConsignmentItemYesNoView
 
 import scala.concurrent.Future
@@ -64,7 +63,7 @@ class RemoveConsignmentItemYesNoControllerSpec extends SpecBase with AppWithDefa
       "must redirect to cross check page and remove consignment item at specified index" in {
         val userAnswers = emptyUserAnswers
           .setValue(ItemSection(houseConsignmentIndex, itemIndex), Json.obj("foo" -> "bar"))
-          .setValue(ItemSection(houseConsignmentIndex, itemIndex), __ \ SequenceNumber, 1)
+          .setSequenceNumber(ItemSection(houseConsignmentIndex, itemIndex), 1)
           .setValue(DeclarationGoodsItemNumberPage(houseConsignmentIndex, itemIndex), BigInt(1))
           .setNotRemoved(ItemSection(houseConsignmentIndex, itemIndex))
 
@@ -98,7 +97,7 @@ class RemoveConsignmentItemYesNoControllerSpec extends SpecBase with AppWithDefa
         when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
         val userAnswers = emptyUserAnswers
           .setValue(ItemSection(houseConsignmentIndex, itemIndex), Json.obj("foo" -> "bar"))
-          .setValue(ItemSection(houseConsignmentIndex, itemIndex), __ \ SequenceNumber, 1)
+          .setSequenceNumber(ItemSection(houseConsignmentIndex, itemIndex), 1)
           .setValue(DeclarationGoodsItemNumberPage(houseConsignmentIndex, itemIndex), BigInt(1))
           .setNotRemoved(ItemSection(houseConsignmentIndex, itemIndex))
 

--- a/test/generators/MessagesModelGenerators.scala
+++ b/test/generators/MessagesModelGenerators.scala
@@ -17,8 +17,6 @@
 package generators
 
 import generated._
-import models.Coordinates
-import models.reference.TransportMode.InlandMode
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.{Arbitrary, Gen}
 import scalaxb.XMLCalendar
@@ -73,16 +71,41 @@ trait MessagesModelGenerators {
   implicit lazy val arbitraryMESSAGESequence: Arbitrary[MESSAGESequence] =
     Arbitrary {
       for {
-        messageSender          <- Gen.alphaNumStr
-        preparationDateAndTime <- arbitrary[XMLGregorianCalendar]
-        messageIdentification  <- Gen.alphaNumStr
-        correlationIdentifier  <- Gen.option(Gen.alphaNumStr)
+        messageSender                   <- Gen.alphaNumStr
+        messagE_1Sequence2              <- arbitrary[MESSAGE_1Sequence]
+        messagE_TYPESequence3           <- arbitrary[MESSAGE_TYPESequence]
+        correlatioN_IDENTIFIERSequence4 <- arbitrary[CORRELATION_IDENTIFIERSequence]
       } yield MESSAGESequence(
         messageSender = messageSender,
-        messageRecipient = "",
+        messagE_1Sequence2 = messagE_1Sequence2,
+        messagE_TYPESequence3 = messagE_TYPESequence3,
+        correlatioN_IDENTIFIERSequence4 = correlatioN_IDENTIFIERSequence4
+      )
+    }
+
+  implicit lazy val arbitraryMESSAGE_1Sequence: Arbitrary[MESSAGE_1Sequence] =
+    Arbitrary {
+      for {
+        messageRecipient       <- Gen.alphaNumStr
+        preparationDateAndTime <- arbitrary[XMLGregorianCalendar]
+        messageIdentification  <- Gen.alphaNumStr
+      } yield MESSAGE_1Sequence(
+        messageRecipient = messageRecipient,
         preparationDateAndTime = preparationDateAndTime,
-        messageIdentification = messageIdentification,
-        messageType = CC043C,
+        messageIdentification = messageIdentification
+      )
+    }
+
+  implicit lazy val arbitraryMESSAGE_TYPESequence: Arbitrary[MESSAGE_TYPESequence] =
+    Arbitrary {
+      MESSAGE_TYPESequence(CC043C)
+    }
+
+  implicit lazy val arbitraryCORRELATION_IDENTIFIERSequence: Arbitrary[CORRELATION_IDENTIFIERSequence] =
+    Arbitrary {
+      for {
+        correlationIdentifier <- Gen.option(Gen.alphaNumStr)
+      } yield CORRELATION_IDENTIFIERSequence(
         correlationIdentifier = correlationIdentifier
       )
     }
@@ -214,7 +237,7 @@ trait MessagesModelGenerators {
   implicit lazy val arbitraryHouseConsignmentType04: Arbitrary[HouseConsignmentType04] =
     Arbitrary {
       for {
-        sequenceNumber          <- arbitrary[BigInt]
+        sequenceNumber          <- positiveBigInts.map(_.toString())
         grossMass               <- positiveBigDecimals
         consignor               <- Gen.option(arbitrary[ConsignorType06])
         consignee               <- Gen.option(arbitrary[ConsigneeType04])
@@ -293,7 +316,7 @@ trait MessagesModelGenerators {
   implicit lazy val arbitraryDepartureTransportMeansType02: Arbitrary[DepartureTransportMeansType02] =
     Arbitrary {
       for {
-        sequenceNumber       <- arbitrary[BigInt]
+        sequenceNumber       <- positiveBigInts.map(_.toString())
         typeOfIdentification <- Gen.alphaNumStr
         identificationNumber <- Gen.alphaNumStr
         nationality          <- Gen.alphaNumStr
@@ -308,7 +331,7 @@ trait MessagesModelGenerators {
   implicit lazy val arbitraryTransportEquipmentType05: Arbitrary[TransportEquipmentType05] =
     Arbitrary {
       for {
-        sequenceNumber                <- arbitrary[BigInt]
+        sequenceNumber                <- positiveBigInts.map(_.toString())
         containerIdentificationNumber <- Gen.option(Gen.alphaNumStr)
         seals                         <- arbitrary[Seq[SealType04]]
         goodsReferences               <- arbitrary[Seq[GoodsReferenceType02]]
@@ -324,7 +347,7 @@ trait MessagesModelGenerators {
   implicit lazy val arbitraryTransportEquipmentType07: Arbitrary[TransportEquipmentType07] =
     Arbitrary {
       for {
-        sequenceNumber                <- arbitrary[BigInt]
+        sequenceNumber                <- positiveBigInts.map(_.toString())
         containerIdentificationNumber <- Gen.option(Gen.alphaNumStr)
         seals                         <- arbitrary[Seq[SealType04]]
         numberOfSeals                 <- Gen.option(positiveBigInts)
@@ -341,7 +364,7 @@ trait MessagesModelGenerators {
   implicit lazy val arbitraryAdditionalReferenceType02: Arbitrary[AdditionalReferenceType02] =
     Arbitrary {
       for {
-        sequenceNumber <- arbitrary[BigInt]
+        sequenceNumber <- positiveBigInts.map(_.toString())
         typeVal        <- Gen.alphaNumStr
         refNum         <- Gen.option(Gen.alphaNumStr)
       } yield AdditionalReferenceType02(
@@ -354,7 +377,7 @@ trait MessagesModelGenerators {
   implicit lazy val arbitraryAdditionalReferenceType03: Arbitrary[AdditionalReferenceType03] =
     Arbitrary {
       for {
-        sequenceNumber <- arbitrary[BigInt]
+        sequenceNumber <- positiveBigInts.map(_.toString())
         typeVal        <- Gen.alphaNumStr
         refNum         <- Gen.option(Gen.alphaNumStr)
       } yield AdditionalReferenceType03(
@@ -367,7 +390,7 @@ trait MessagesModelGenerators {
   implicit lazy val arbitraryAdditionalInformationType02: Arbitrary[AdditionalInformationType02] =
     Arbitrary {
       for {
-        sequenceNumber <- arbitrary[BigInt]
+        sequenceNumber <- positiveBigInts.map(_.toString())
         code           <- Gen.alphaNumStr
         text           <- Gen.option(Gen.alphaNumStr)
       } yield AdditionalInformationType02(
@@ -380,7 +403,7 @@ trait MessagesModelGenerators {
   implicit lazy val arbitrarySealType04: Arbitrary[SealType04] =
     Arbitrary {
       for {
-        sequenceNumber <- arbitrary[BigInt]
+        sequenceNumber <- positiveBigInts.map(_.toString())
         identifier     <- Gen.alphaNumStr
       } yield SealType04(
         sequenceNumber = sequenceNumber,
@@ -391,7 +414,7 @@ trait MessagesModelGenerators {
   implicit lazy val arbitraryPackageType04: Arbitrary[PackagingType02] =
     Arbitrary {
       for {
-        sequenceNumber   <- arbitrary[BigInt]
+        sequenceNumber   <- positiveBigInts.map(_.toString())
         typeOfPackages   <- Gen.alphaNumStr
         numberOfPackages <- Gen.option(positiveBigInts)
         shippingMarks    <- Gen.option(Gen.alphaNumStr)
@@ -407,7 +430,7 @@ trait MessagesModelGenerators {
   implicit lazy val arbitraryGoodsReferenceType02: Arbitrary[GoodsReferenceType02] =
     Arbitrary {
       for {
-        sequenceNumber             <- arbitrary[BigInt]
+        sequenceNumber             <- positiveBigInts.map(_.toString())
         declarationGoodsItemNumber <- positiveBigInts
       } yield GoodsReferenceType02(
         sequenceNumber = sequenceNumber,
@@ -418,7 +441,7 @@ trait MessagesModelGenerators {
   implicit lazy val arbitraryGoodsReferenceType01: Arbitrary[GoodsReferenceType01] =
     Arbitrary {
       for {
-        sequenceNumber             <- arbitrary[BigInt]
+        sequenceNumber             <- positiveBigInts.map(_.toString())
         declarationGoodsItemNumber <- positiveBigInts
       } yield GoodsReferenceType01(
         sequenceNumber = sequenceNumber,
@@ -433,7 +456,7 @@ trait MessagesModelGenerators {
         cusCode            <- Gen.option(Gen.alphaNumStr)
         commodityCode      <- Gen.option(arbitrary[CommodityCodeType05])
         dangerousGoods     <- arbitrary[Seq[DangerousGoodsType01]]
-        goodsMeasure       <- arbitrary[GoodsMeasureType03]
+        goodsMeasure       <- Gen.option(arbitrary[GoodsMeasureType03])
       } yield CommodityType08(
         descriptionOfGoods = descriptionOfGoods,
         cusCode = cusCode,
@@ -457,7 +480,7 @@ trait MessagesModelGenerators {
   implicit lazy val arbitraryDangerousGoodsType01: Arbitrary[DangerousGoodsType01] =
     Arbitrary {
       for {
-        sequenceNumber <- arbitrary[BigInt]
+        sequenceNumber <- positiveBigInts.map(_.toString())
         unNumber       <- Gen.alphaNumStr
       } yield DangerousGoodsType01(
         sequenceNumber = sequenceNumber,
@@ -476,7 +499,7 @@ trait MessagesModelGenerators {
       )
     }
 
-  implicit lazy val arbitraryEndorsement03: Arbitrary[generated.EndorsementType03] = Arbitrary {
+  implicit lazy val arbitraryEndorsementType03: Arbitrary[EndorsementType03] = Arbitrary {
     for {
       date      <- arbitraryXMLGregorianCalendar.arbitrary
       authority <- Gen.alphaNumStr
@@ -485,26 +508,25 @@ trait MessagesModelGenerators {
     } yield EndorsementType03(date, authority, place, country)
   }
 
-  implicit lazy val coordinates: Arbitrary[Coordinates] = Arbitrary {
+  implicit lazy val arbitraryTranshipmentType02: Arbitrary[TranshipmentType02] = Arbitrary {
     for {
-      long <- Gen.alphaNumStr
-      lat  <- Gen.alphaNumStr
-    } yield Coordinates(long, lat)
+      containerIndicator <- arbitraryFlag.arbitrary
+      transportMeans     <- arbitrary[TransportMeansType02]
+    } yield TranshipmentType02(containerIndicator, transportMeans)
   }
 
-  implicit lazy val arbTranshipment02: Arbitrary[TranshipmentType02] = Arbitrary {
+  implicit lazy val arbitraryTransportMeansType02: Arbitrary[TransportMeansType02] = Arbitrary {
     for {
-      flag            <- arbitraryFlag.arbitrary
-      sequenceNumber  <- Gen.alphaNumStr
+      sequenceNumber  <- positiveBigInts.map(_.toString())
       typeValue       <- Gen.alphaNumStr
       referenceNumber <- Gen.alphaNumStr
-    } yield TranshipmentType02(flag, TransportMeansType02(sequenceNumber, typeValue, referenceNumber))
+    } yield TransportMeansType02(sequenceNumber, typeValue, referenceNumber)
   }
 
   implicit lazy val arbitraryIncidentType04: Arbitrary[generated.IncidentType04] =
     Arbitrary {
       for {
-        sequenceNumber <- arbitrary[BigInt]
+        sequenceNumber <- positiveBigInts.map(_.toString())
         code           <- Gen.alphaNumStr
         text           <- Gen.alphaNumStr
         loc            <- arbitraryLocationType02.arbitrary
@@ -523,7 +545,7 @@ trait MessagesModelGenerators {
   implicit lazy val arbitraryConsignmentItemType04: Arbitrary[ConsignmentItemType04] =
     Arbitrary {
       for {
-        goodsItemNumber            <- arbitrary[BigInt]
+        goodsItemNumber            <- positiveBigInts.map(_.toString())
         declarationGoodsItemNumber <- positiveBigInts
         commodity                  <- arbitrary[CommodityType08]
       } yield ConsignmentItemType04(
@@ -603,7 +625,7 @@ trait MessagesModelGenerators {
   implicit lazy val arbitrarySupportingDocumentType02: Arbitrary[SupportingDocumentType02] =
     Arbitrary {
       for {
-        sequenceNumber          <- arbitrary[BigInt]
+        sequenceNumber          <- positiveBigInts.map(_.toString())
         typeValue               <- Gen.alphaNumStr
         referenceNumber         <- Gen.alphaNumStr
         complementOfInformation <- Gen.option(Gen.alphaNumStr)
@@ -618,7 +640,7 @@ trait MessagesModelGenerators {
   implicit lazy val arbitraryTransportDocumentType02: Arbitrary[TransportDocumentType02] =
     Arbitrary {
       for {
-        sequenceNumber  <- arbitrary[BigInt]
+        sequenceNumber  <- positiveBigInts.map(_.toString())
         typeValue       <- Gen.alphaNumStr
         referenceNumber <- Gen.alphaNumStr
       } yield TransportDocumentType02(
@@ -664,11 +686,6 @@ trait MessagesModelGenerators {
   implicit lazy val arbitraryFlag: Arbitrary[Flag] =
     Arbitrary {
       Gen.oneOf(Number0, Number1)
-    }
-
-  implicit lazy val arbitraryInlandMode: Arbitrary[InlandMode] =
-    Arbitrary {
-      Gen.oneOf(InlandMode("1", "Maritime Transport"), InlandMode("2", "Rail Transport"))
     }
 
   implicit lazy val arbitraryUnloadingRemarkType: Arbitrary[UnloadingRemarkType] =

--- a/test/generators/ModelGenerators.scala
+++ b/test/generators/ModelGenerators.scala
@@ -18,6 +18,7 @@ package generators
 
 import models.P5.ArrivalMessageType
 import models._
+import models.reference.TransportMode.InlandMode
 import models.reference._
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.{Arbitrary, Gen}
@@ -220,5 +221,17 @@ trait ModelGenerators {
   implicit lazy val arbitraryDocType: Arbitrary[DocType] =
     Arbitrary {
       Gen.oneOf(DocType.values)
+    }
+
+  implicit lazy val arbitraryCoordinates: Arbitrary[Coordinates] = Arbitrary {
+    for {
+      long <- Gen.alphaNumStr
+      lat  <- Gen.alphaNumStr
+    } yield Coordinates(long, lat)
+  }
+
+  implicit lazy val arbitraryInlandMode: Arbitrary[InlandMode] =
+    Arbitrary {
+      Gen.oneOf(InlandMode("1", "Maritime Transport"), InlandMode("2", "Rail Transport"))
     }
 }

--- a/test/models/DocumentSpec.scala
+++ b/test/models/DocumentSpec.scala
@@ -32,7 +32,7 @@ class DocumentSpec extends SpecBase with ScalaCheckPropertyChecks {
       forAll(arbitrary[BigInt], Gen.alphaNumStr, Gen.alphaNumStr, Gen.option(Gen.alphaNumStr), Gen.alphaNumStr) {
         (sequenceNumber, typeValue, referenceNumber, complementOfInformation, description) =>
           val ie043Document = SupportingDocumentType02(
-            sequenceNumber = sequenceNumber,
+            sequenceNumber = sequenceNumber.toString(),
             typeValue = typeValue,
             referenceNumber = referenceNumber,
             complementOfInformation = complementOfInformation
@@ -59,7 +59,7 @@ class DocumentSpec extends SpecBase with ScalaCheckPropertyChecks {
       forAll(arbitrary[BigInt], Gen.alphaNumStr, Gen.alphaNumStr, Gen.alphaNumStr) {
         (sequenceNumber, typeValue, referenceNumber, description) =>
           val ie043Document = TransportDocumentType02(
-            sequenceNumber = sequenceNumber,
+            sequenceNumber = sequenceNumber.toString(),
             typeValue = typeValue,
             referenceNumber = referenceNumber
           )
@@ -84,7 +84,7 @@ class DocumentSpec extends SpecBase with ScalaCheckPropertyChecks {
       forAll(arbitrary[BigInt], Gen.alphaNumStr, Gen.alphaNumStr, Gen.option(Gen.alphaNumStr), Gen.alphaNumStr) {
         (sequenceNumber, typeValue, referenceNumber, complementOfInformation, description) =>
           val ie043Document = PreviousDocumentType06(
-            sequenceNumber = sequenceNumber,
+            sequenceNumber = sequenceNumber.toString(),
             typeValue = typeValue,
             referenceNumber = referenceNumber,
             complementOfInformation = complementOfInformation
@@ -111,10 +111,10 @@ class DocumentSpec extends SpecBase with ScalaCheckPropertyChecks {
       forAll(arbitrary[BigInt], Gen.alphaNumStr, Gen.alphaNumStr, Gen.option(arbitrary[BigInt]), Gen.option(Gen.alphaNumStr), Gen.alphaNumStr) {
         (sequenceNumber, typeValue, referenceNumber, goodsItemNumber, complementOfInformation, description) =>
           val ie043Document = PreviousDocumentType04(
-            sequenceNumber = sequenceNumber,
+            sequenceNumber = sequenceNumber.toString(),
             typeValue = typeValue,
             referenceNumber = referenceNumber,
-            goodsItemNumber = goodsItemNumber,
+            goodsItemNumber = goodsItemNumber.map(_.toString()),
             complementOfInformation = complementOfInformation
           )
 

--- a/test/services/submission/SubmissionServiceSpec.scala
+++ b/test/services/submission/SubmissionServiceSpec.scala
@@ -75,11 +75,17 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
 
         result mustBe MESSAGESequence(
           messageSender = eoriNumber.value,
-          messageRecipient = "NTA.GB",
-          preparationDateAndTime = XMLCalendar("2020-01-01T09:30:00"),
-          messageIdentification = "foo",
-          messageType = CC044C,
-          correlationIdentifier = None
+          messagE_1Sequence2 = MESSAGE_1Sequence(
+            messageRecipient = "NTA.GB",
+            preparationDateAndTime = XMLCalendar("2020-01-01T09:30:00"),
+            messageIdentification = "foo"
+          ),
+          messagE_TYPESequence3 = MESSAGE_TYPESequence(
+            messageType = CC044C
+          ),
+          correlatioN_IDENTIFIERSequence4 = CORRELATION_IDENTIFIERSequence(
+            correlationIdentifier = None
+          )
         )
       }
 
@@ -88,11 +94,17 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
 
         result mustBe MESSAGESequence(
           messageSender = eoriNumber.value,
-          messageRecipient = "NTA.XI",
-          preparationDateAndTime = XMLCalendar("2020-01-01T09:30:00"),
-          messageIdentification = "foo",
-          messageType = CC044C,
-          correlationIdentifier = None
+          messagE_1Sequence2 = MESSAGE_1Sequence(
+            messageRecipient = "NTA.XI",
+            preparationDateAndTime = XMLCalendar("2020-01-01T09:30:00"),
+            messageIdentification = "foo"
+          ),
+          messagE_TYPESequence3 = MESSAGE_TYPESequence(
+            messageType = CC044C
+          ),
+          correlatioN_IDENTIFIERSequence4 = CORRELATION_IDENTIFIERSequence(
+            correlationIdentifier = None
+          )
         )
       }
     }
@@ -371,51 +383,51 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           consignment =>
             val transportEquipment = Seq(
               TransportEquipmentType05(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 containerIdentificationNumber = Some("originalTransportEquipment1ContainerIdentificationNumber"),
                 numberOfSeals = 2,
                 Seal = Seq(
                   SealType04(
-                    sequenceNumber = 1,
+                    sequenceNumber = "1",
                     identifier = "originalTransportEquipment1SealIdentifier1"
                   ),
                   SealType04(
-                    sequenceNumber = 2,
+                    sequenceNumber = "2",
                     identifier = "originalTransportEquipment1SealIdentifier2"
                   )
                 ),
                 GoodsReference = Seq(
                   GoodsReferenceType02(
-                    sequenceNumber = 1,
+                    sequenceNumber = "1",
                     declarationGoodsItemNumber = 1
                   ),
                   GoodsReferenceType02(
-                    sequenceNumber = 2,
+                    sequenceNumber = "2",
                     declarationGoodsItemNumber = 2
                   )
                 )
               ),
               TransportEquipmentType05(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 containerIdentificationNumber = Some("originalTransportEquipment2ContainerIdentificationNumber"),
                 numberOfSeals = 2,
                 Seal = Seq(
                   SealType04(
-                    sequenceNumber = 1,
+                    sequenceNumber = "1",
                     identifier = "originalTransportEquipment2SealIdentifier1"
                   ),
                   SealType04(
-                    sequenceNumber = 2,
+                    sequenceNumber = "2",
                     identifier = "originalTransportEquipment2SealIdentifier2"
                   )
                 ),
                 GoodsReference = Seq(
                   GoodsReferenceType02(
-                    sequenceNumber = 1,
+                    sequenceNumber = "1",
                     declarationGoodsItemNumber = 3
                   ),
                   GoodsReferenceType02(
-                    sequenceNumber = 2,
+                    sequenceNumber = "2",
                     declarationGoodsItemNumber = 4
                   )
                 )
@@ -490,75 +502,75 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
 
             result mustBe Seq(
               TransportEquipmentType03(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 containerIdentificationNumber = None,
                 numberOfSeals = Some(2),
                 Seal = Seq(
                   SealType02(
-                    sequenceNumber = 2,
+                    sequenceNumber = "2",
                     identifier = "newTransportEquipment1SealIdentifier2"
                   ),
                   SealType02(
-                    sequenceNumber = 3,
+                    sequenceNumber = "3",
                     identifier = "newTransportEquipment1SealIdentifier3"
                   )
                 ),
                 GoodsReference = Seq(
                   GoodsReferenceType01(
-                    sequenceNumber = 2,
+                    sequenceNumber = "2",
                     declarationGoodsItemNumber = 5
                   ),
                   GoodsReferenceType01(
-                    sequenceNumber = 3,
+                    sequenceNumber = "3",
                     declarationGoodsItemNumber = 6
                   )
                 )
               ),
               TransportEquipmentType03(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 containerIdentificationNumber = Some("newTransportEquipment2ContainerIdentificationNumber"),
                 numberOfSeals = Some(2),
                 Seal = Seq(
                   SealType02(
-                    sequenceNumber = 1,
+                    sequenceNumber = "1",
                     identifier = "newTransportEquipment2SealIdentifier1"
                   ),
                   SealType02(
-                    sequenceNumber = 3,
+                    sequenceNumber = "3",
                     identifier = "newTransportEquipment2SealIdentifier3"
                   )
                 ),
                 GoodsReference = Seq(
                   GoodsReferenceType01(
-                    sequenceNumber = 2,
+                    sequenceNumber = "2",
                     declarationGoodsItemNumber = 7
                   ),
                   GoodsReferenceType01(
-                    sequenceNumber = 3,
+                    sequenceNumber = "3",
                     declarationGoodsItemNumber = 8
                   )
                 )
               ),
               TransportEquipmentType03(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 containerIdentificationNumber = None,
                 numberOfSeals = None,
                 Seal = Nil,
                 GoodsReference = Nil
               ),
               TransportEquipmentType03(
-                sequenceNumber = 4,
+                sequenceNumber = "4",
                 containerIdentificationNumber = Some("newTransportEquipment4ContainerIdentificationNumber"),
                 numberOfSeals = Some(1),
                 Seal = Seq(
                   SealType02(
-                    sequenceNumber = 1,
+                    sequenceNumber = "1",
                     identifier = "newTransportEquipment4SealIdentifier1"
                   )
                 ),
                 GoodsReference = Seq(
                   GoodsReferenceType01(
-                    sequenceNumber = 1,
+                    sequenceNumber = "1",
                     declarationGoodsItemNumber = 9
                   )
                 )
@@ -572,51 +584,51 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           consignment =>
             val transportEquipment = Seq(
               TransportEquipmentType05(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 containerIdentificationNumber = Some("originalTransportEquipment1ContainerIdentificationNumber"),
                 numberOfSeals = 2,
                 Seal = Seq(
                   SealType04(
-                    sequenceNumber = 1,
+                    sequenceNumber = "1",
                     identifier = "originalTransportEquipment1SealIdentifier1"
                   ),
                   SealType04(
-                    sequenceNumber = 2,
+                    sequenceNumber = "2",
                     identifier = "originalTransportEquipment1SealIdentifier2"
                   )
                 ),
                 GoodsReference = Seq(
                   GoodsReferenceType02(
-                    sequenceNumber = 1,
+                    sequenceNumber = "1",
                     declarationGoodsItemNumber = 1
                   ),
                   GoodsReferenceType02(
-                    sequenceNumber = 2,
+                    sequenceNumber = "2",
                     declarationGoodsItemNumber = 2
                   )
                 )
               ),
               TransportEquipmentType05(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 containerIdentificationNumber = Some("originalTransportEquipment2ContainerIdentificationNumber"),
                 numberOfSeals = 2,
                 Seal = Seq(
                   SealType04(
-                    sequenceNumber = 1,
+                    sequenceNumber = "1",
                     identifier = "originalTransportEquipment2SealIdentifier1"
                   ),
                   SealType04(
-                    sequenceNumber = 2,
+                    sequenceNumber = "2",
                     identifier = "originalTransportEquipment2SealIdentifier2"
                   )
                 ),
                 GoodsReference = Seq(
                   GoodsReferenceType02(
-                    sequenceNumber = 1,
+                    sequenceNumber = "1",
                     declarationGoodsItemNumber = 3
                   ),
                   GoodsReferenceType02(
-                    sequenceNumber = 2,
+                    sequenceNumber = "2",
                     declarationGoodsItemNumber = 4
                   )
                 )
@@ -684,25 +696,25 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           consignment =>
             val departureTransportMeans = Seq(
               DepartureTransportMeansType02(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeOfIdentification = "originalTypeOfIdentification1",
                 identificationNumber = "originalIdentificationNumber1",
                 nationality = "originalNationality1"
               ),
               DepartureTransportMeansType02(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeOfIdentification = "originalTypeOfIdentification2",
                 identificationNumber = "originalIdentificationNumber2",
                 nationality = "originalNationality2"
               ),
               DepartureTransportMeansType02(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeOfIdentification = "originalTypeOfIdentification3",
                 identificationNumber = "originalIdentificationNumber3",
                 nationality = "originalNationality3"
               ),
               DepartureTransportMeansType02(
-                sequenceNumber = 4,
+                sequenceNumber = "4",
                 typeOfIdentification = "originalTypeOfIdentification4",
                 identificationNumber = "originalIdentificationNumber4",
                 nationality = "originalNationality4"
@@ -750,25 +762,25 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
 
             result mustBe Seq(
               DepartureTransportMeansType04(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeOfIdentification = Some("newTypeOfIdentification1"),
                 identificationNumber = None,
                 nationality = None
               ),
               DepartureTransportMeansType04(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeOfIdentification = None,
                 identificationNumber = Some("newIdentificationNumber2"),
                 nationality = Some("newNationality2")
               ),
               DepartureTransportMeansType04(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeOfIdentification = None,
                 identificationNumber = None,
                 nationality = None
               ),
               DepartureTransportMeansType04(
-                sequenceNumber = 5,
+                sequenceNumber = "5",
                 typeOfIdentification = Some("newTypeOfIdentification5"),
                 identificationNumber = Some("newIdentificationNumber5"),
                 nationality = Some("newNationality5")
@@ -782,13 +794,13 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           consignment =>
             val departureTransportMeans = Seq(
               DepartureTransportMeansType02(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeOfIdentification = "originalTypeOfIdentification1",
                 identificationNumber = "originalIdentificationNumber1",
                 nationality = "originalNationality1"
               ),
               DepartureTransportMeansType02(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeOfIdentification = "originalTypeOfIdentification2",
                 identificationNumber = "originalIdentificationNumber2",
                 nationality = "originalNationality2"
@@ -829,25 +841,25 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           consignment =>
             val supportingDocuments = Seq(
               SupportingDocumentType02(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = "originalTypeValue1",
                 referenceNumber = "originalReferenceNumber1",
                 complementOfInformation = Some("originalComplementOfInformation1")
               ),
               SupportingDocumentType02(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = "originalTypeValue2",
                 referenceNumber = "originalReferenceNumber2",
                 complementOfInformation = Some("originalComplementOfInformation2")
               ),
               SupportingDocumentType02(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeValue = "originalTypeValue3",
                 referenceNumber = "originalReferenceNumber3",
                 complementOfInformation = Some("originalComplementOfInformation3")
               ),
               SupportingDocumentType02(
-                sequenceNumber = 4,
+                sequenceNumber = "4",
                 typeValue = "originalTypeValue4",
                 referenceNumber = "originalReferenceNumber4",
                 complementOfInformation = Some("originalComplementOfInformation4")
@@ -888,25 +900,25 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
 
             result mustBe Seq(
               SupportingDocumentType03(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = Some("newTypeValue1"),
                 referenceNumber = None,
                 complementOfInformation = None
               ),
               SupportingDocumentType03(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = None,
                 referenceNumber = Some("newReferenceNumber2"),
                 complementOfInformation = Some("newComplementOfInformation2")
               ),
               SupportingDocumentType03(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeValue = None,
                 referenceNumber = None,
                 complementOfInformation = None
               ),
               SupportingDocumentType03(
-                sequenceNumber = 5,
+                sequenceNumber = "5",
                 typeValue = Some("newTypeValue5"),
                 referenceNumber = Some("newReferenceNumber5"),
                 complementOfInformation = Some("newComplementOfInformation5")
@@ -920,13 +932,13 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           consignment =>
             val supportingDocuments = Seq(
               SupportingDocumentType02(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = "originalTypeValue1",
                 referenceNumber = "originalReferenceNumber1",
                 complementOfInformation = Some("originalComplementOfInformation1")
               ),
               SupportingDocumentType02(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = "originalTypeValue2",
                 referenceNumber = "originalReferenceNumber2",
                 complementOfInformation = Some("originalComplementOfInformation2")
@@ -965,22 +977,22 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           consignment =>
             val transportDocuments = Seq(
               TransportDocumentType02(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = "originalTypeValue1",
                 referenceNumber = "originalReferenceNumber1"
               ),
               TransportDocumentType02(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = "originalTypeValue2",
                 referenceNumber = "originalReferenceNumber2"
               ),
               TransportDocumentType02(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeValue = "originalTypeValue3",
                 referenceNumber = "originalReferenceNumber3"
               ),
               TransportDocumentType02(
-                sequenceNumber = 4,
+                sequenceNumber = "4",
                 typeValue = "originalTypeValue4",
                 referenceNumber = "originalReferenceNumber4"
               )
@@ -1016,22 +1028,22 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
 
             result mustBe Seq(
               TransportDocumentType03(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = Some("newTypeValue1"),
                 referenceNumber = None
               ),
               TransportDocumentType03(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = None,
                 referenceNumber = Some("newReferenceNumber2")
               ),
               TransportDocumentType03(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeValue = None,
                 referenceNumber = None
               ),
               TransportDocumentType03(
-                sequenceNumber = 5,
+                sequenceNumber = "5",
                 typeValue = Some("newTypeValue5"),
                 referenceNumber = Some("newReferenceNumber5")
               )
@@ -1044,12 +1056,12 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           consignment =>
             val transportDocuments = Seq(
               TransportDocumentType02(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = "originalTypeValue1",
                 referenceNumber = "originalReferenceNumber1"
               ),
               TransportDocumentType02(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = "originalTypeValue2",
                 referenceNumber = "originalReferenceNumber2"
               )
@@ -1085,22 +1097,22 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           consignment =>
             val additionalReferences = Seq(
               AdditionalReferenceType03(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = "originalTypeValue1",
                 referenceNumber = Some("originalReferenceNumber1")
               ),
               AdditionalReferenceType03(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = "originalTypeValue2",
                 referenceNumber = Some("originalReferenceNumber2")
               ),
               AdditionalReferenceType03(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeValue = "originalTypeValue3",
                 referenceNumber = Some("originalReferenceNumber3")
               ),
               AdditionalReferenceType03(
-                sequenceNumber = 4,
+                sequenceNumber = "4",
                 typeValue = "originalTypeValue4",
                 referenceNumber = Some("originalReferenceNumber4")
               )
@@ -1135,22 +1147,22 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
 
             result mustBe Seq(
               AdditionalReferenceType06(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = Some("newTypeValue1"),
                 referenceNumber = None
               ),
               AdditionalReferenceType06(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = None,
                 referenceNumber = Some("newReferenceNumber2")
               ),
               AdditionalReferenceType06(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeValue = None,
                 referenceNumber = None
               ),
               AdditionalReferenceType06(
-                sequenceNumber = 5,
+                sequenceNumber = "5",
                 typeValue = Some("newTypeValue5"),
                 referenceNumber = Some("newReferenceNumber5")
               )
@@ -1163,12 +1175,12 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           consignment =>
             val additionalReferences = Seq(
               AdditionalReferenceType03(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = "originalTypeValue1",
                 referenceNumber = Some("originalReferenceNumber1")
               ),
               AdditionalReferenceType03(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = "originalTypeValue2",
                 referenceNumber = Some("originalReferenceNumber2")
               )
@@ -1214,7 +1226,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           forAll(arbitrary[HouseConsignmentType04]) {
             houseConsignment =>
               val ie043 = houseConsignment.copy(
-                sequenceNumber = sequenceNumber,
+                sequenceNumber = sequenceNumber.toString,
                 grossMass = 50
               )
 
@@ -1234,7 +1246,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
         forAll(arbitrary[HouseConsignmentType04]) {
           houseConsignment =>
             val ie043 = houseConsignment.copy(
-              sequenceNumber = sequenceNumber,
+              sequenceNumber = sequenceNumber.toString,
               grossMass = grossMass
             )
 
@@ -1259,32 +1271,32 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           houseConsignment =>
             val departureTransportMeans = Seq(
               DepartureTransportMeansType02(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeOfIdentification = "originalTypeOfIdentification1",
                 identificationNumber = "originalIdentificationNumber1",
                 nationality = "originalNationality1"
               ),
               DepartureTransportMeansType02(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeOfIdentification = "originalTypeOfIdentification2",
                 identificationNumber = "originalIdentificationNumber2",
                 nationality = "originalNationality2"
               ),
               DepartureTransportMeansType02(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeOfIdentification = "originalTypeOfIdentification3",
                 identificationNumber = "originalIdentificationNumber3",
                 nationality = "originalNationality3"
               ),
               DepartureTransportMeansType02(
-                sequenceNumber = 4,
+                sequenceNumber = "4",
                 typeOfIdentification = "originalTypeOfIdentification4",
                 identificationNumber = "originalIdentificationNumber4",
                 nationality = "originalNationality4"
               )
             )
             val ie043 = houseConsignment.copy(
-              sequenceNumber = sequenceNumber,
+              sequenceNumber = sequenceNumber.toString,
               DepartureTransportMeans = departureTransportMeans
             )
 
@@ -1332,25 +1344,25 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
 
             result mustBe Seq(
               DepartureTransportMeansType04(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeOfIdentification = Some("newTypeOfIdentification1"),
                 identificationNumber = None,
                 nationality = None
               ),
               DepartureTransportMeansType04(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeOfIdentification = None,
                 identificationNumber = Some("newIdentificationNumber2"),
                 nationality = Some("newNationality2")
               ),
               DepartureTransportMeansType04(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeOfIdentification = None,
                 identificationNumber = None,
                 nationality = None
               ),
               DepartureTransportMeansType04(
-                sequenceNumber = 5,
+                sequenceNumber = "5",
                 typeOfIdentification = Some("newTypeOfIdentification5"),
                 identificationNumber = Some("newIdentificationNumber5"),
                 nationality = Some("newNationality5")
@@ -1364,20 +1376,20 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           houseConsignment =>
             val departureTransportMeans = Seq(
               DepartureTransportMeansType02(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeOfIdentification = "originalTypeOfIdentification1",
                 identificationNumber = "originalIdentificationNumber1",
                 nationality = "originalNationality1"
               ),
               DepartureTransportMeansType02(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeOfIdentification = "originalTypeOfIdentification2",
                 identificationNumber = "originalIdentificationNumber2",
                 nationality = "originalNationality2"
               )
             )
             val ie043 = houseConsignment.copy(
-              sequenceNumber = sequenceNumber,
+              sequenceNumber = sequenceNumber.toString,
               DepartureTransportMeans = departureTransportMeans
             )
 
@@ -1418,32 +1430,32 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           houseConsignment =>
             val supportingDocuments = Seq(
               SupportingDocumentType02(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = "originalTypeValue1",
                 referenceNumber = "originalReferenceNumber1",
                 complementOfInformation = Some("originalComplementOfInformation1")
               ),
               SupportingDocumentType02(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = "originalTypeValue2",
                 referenceNumber = "originalReferenceNumber2",
                 complementOfInformation = Some("originalComplementOfInformation2")
               ),
               SupportingDocumentType02(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeValue = "originalTypeValue3",
                 referenceNumber = "originalReferenceNumber3",
                 complementOfInformation = Some("originalComplementOfInformation3")
               ),
               SupportingDocumentType02(
-                sequenceNumber = 4,
+                sequenceNumber = "4",
                 typeValue = "originalTypeValue4",
                 referenceNumber = "originalReferenceNumber4",
                 complementOfInformation = Some("originalComplementOfInformation4")
               )
             )
             val ie043 = houseConsignment.copy(
-              sequenceNumber = sequenceNumber,
+              sequenceNumber = sequenceNumber.toString,
               SupportingDocument = supportingDocuments
             )
 
@@ -1482,25 +1494,25 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
 
             result mustBe Seq(
               SupportingDocumentType03(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = Some("newTypeValue1"),
                 referenceNumber = None,
                 complementOfInformation = None
               ),
               SupportingDocumentType03(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = None,
                 referenceNumber = Some("newReferenceNumber2"),
                 complementOfInformation = Some("newComplementOfInformation2")
               ),
               SupportingDocumentType03(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeValue = None,
                 referenceNumber = None,
                 complementOfInformation = None
               ),
               SupportingDocumentType03(
-                sequenceNumber = 5,
+                sequenceNumber = "5",
                 typeValue = Some("newTypeValue5"),
                 referenceNumber = Some("newReferenceNumber5"),
                 complementOfInformation = Some("newComplementOfInformation5")
@@ -1514,20 +1526,20 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           houseConsignment =>
             val supportingDocuments = Seq(
               SupportingDocumentType02(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = "originalTypeValue1",
                 referenceNumber = "originalReferenceNumber1",
                 complementOfInformation = Some("originalComplementOfInformation1")
               ),
               SupportingDocumentType02(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = "originalTypeValue2",
                 referenceNumber = "originalReferenceNumber2",
                 complementOfInformation = Some("originalComplementOfInformation2")
               )
             )
             val ie043 = houseConsignment.copy(
-              sequenceNumber = sequenceNumber,
+              sequenceNumber = sequenceNumber.toString,
               SupportingDocument = supportingDocuments
             )
 
@@ -1564,28 +1576,28 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           houseConsignment =>
             val transportDocuments = Seq(
               TransportDocumentType02(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = "originalTypeValue1",
                 referenceNumber = "originalReferenceNumber1"
               ),
               TransportDocumentType02(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = "originalTypeValue2",
                 referenceNumber = "originalReferenceNumber2"
               ),
               TransportDocumentType02(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeValue = "originalTypeValue3",
                 referenceNumber = "originalReferenceNumber3"
               ),
               TransportDocumentType02(
-                sequenceNumber = 4,
+                sequenceNumber = "4",
                 typeValue = "originalTypeValue4",
                 referenceNumber = "originalReferenceNumber4"
               )
             )
             val ie043 = houseConsignment.copy(
-              sequenceNumber = sequenceNumber,
+              sequenceNumber = sequenceNumber.toString,
               TransportDocument = transportDocuments
             )
 
@@ -1620,22 +1632,22 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
 
             result mustBe Seq(
               TransportDocumentType03(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = Some("newTypeValue1"),
                 referenceNumber = None
               ),
               TransportDocumentType03(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = None,
                 referenceNumber = Some("newReferenceNumber2")
               ),
               TransportDocumentType03(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeValue = None,
                 referenceNumber = None
               ),
               TransportDocumentType03(
-                sequenceNumber = 5,
+                sequenceNumber = "5",
                 typeValue = Some("newTypeValue5"),
                 referenceNumber = Some("newReferenceNumber5")
               )
@@ -1648,18 +1660,18 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           houseConsignment =>
             val transportDocuments = Seq(
               TransportDocumentType02(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = "originalTypeValue1",
                 referenceNumber = "originalReferenceNumber1"
               ),
               TransportDocumentType02(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = "originalTypeValue2",
                 referenceNumber = "originalReferenceNumber2"
               )
             )
             val ie043 = houseConsignment.copy(
-              sequenceNumber = sequenceNumber,
+              sequenceNumber = sequenceNumber.toString,
               TransportDocument = transportDocuments
             )
 
@@ -1694,28 +1706,28 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           houseConsignment =>
             val additionalReferences = Seq(
               AdditionalReferenceType03(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = "originalTypeValue1",
                 referenceNumber = Some("originalReferenceNumber1")
               ),
               AdditionalReferenceType03(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = "originalTypeValue2",
                 referenceNumber = Some("originalReferenceNumber2")
               ),
               AdditionalReferenceType03(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeValue = "originalTypeValue3",
                 referenceNumber = Some("originalReferenceNumber3")
               ),
               AdditionalReferenceType03(
-                sequenceNumber = 4,
+                sequenceNumber = "4",
                 typeValue = "originalTypeValue4",
                 referenceNumber = Some("originalReferenceNumber4")
               )
             )
             val ie043 = houseConsignment.copy(
-              sequenceNumber = sequenceNumber,
+              sequenceNumber = sequenceNumber.toString,
               AdditionalReference = additionalReferences
             )
 
@@ -1753,22 +1765,22 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
 
             result mustBe Seq(
               AdditionalReferenceType06(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = Some("newTypeValue1"),
                 referenceNumber = None
               ),
               AdditionalReferenceType06(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = None,
                 referenceNumber = Some("newReferenceNumber2")
               ),
               AdditionalReferenceType06(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeValue = None,
                 referenceNumber = None
               ),
               AdditionalReferenceType06(
-                sequenceNumber = 5,
+                sequenceNumber = "5",
                 typeValue = Some("newTypeValue5"),
                 referenceNumber = Some("newReferenceNumber5")
               )
@@ -1781,18 +1793,18 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           houseConsignment =>
             val additionalReferences = Seq(
               AdditionalReferenceType03(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = "originalTypeValue1",
                 referenceNumber = Some("originalReferenceNumber1")
               ),
               AdditionalReferenceType03(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = "originalTypeValue2",
                 referenceNumber = Some("originalReferenceNumber2")
               )
             )
             val ie043 = houseConsignment.copy(
-              sequenceNumber = sequenceNumber,
+              sequenceNumber = sequenceNumber.toString,
               AdditionalReference = additionalReferences
             )
 
@@ -1847,13 +1859,15 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
                 )
               ),
               DangerousGoods = Nil,
-              GoodsMeasure = GoodsMeasureType03(
-                grossMass = 100,
-                netMass = Some(50)
+              GoodsMeasure = Some(
+                GoodsMeasureType03(
+                  grossMass = 100,
+                  netMass = Some(50)
+                )
               )
             )
             val ie043 = consignmentItem.copy(
-              goodsItemNumber = sequenceNumber,
+              goodsItemNumber = sequenceNumber.toString,
               Commodity = commodity
             )
 
@@ -1902,13 +1916,15 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
                 )
               ),
               DangerousGoods = Nil,
-              GoodsMeasure = GoodsMeasureType03(
-                grossMass = 100,
-                netMass = Some(50)
+              GoodsMeasure = Some(
+                GoodsMeasureType03(
+                  grossMass = 100,
+                  netMass = Some(50)
+                )
               )
             )
             val ie043 = consignmentItem.copy(
-              goodsItemNumber = sequenceNumber,
+              goodsItemNumber = sequenceNumber.toString,
               Commodity = commodity
             )
 
@@ -1939,32 +1955,32 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           consignmentItem =>
             val packaging = Seq(
               PackagingType02(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeOfPackages = "originalTypeOfPackages1",
                 numberOfPackages = Some(100),
                 shippingMarks = Some("originalShippingMarks1")
               ),
               PackagingType02(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeOfPackages = "originalTypeOfPackages2",
                 numberOfPackages = Some(200),
                 shippingMarks = Some("originalShippingMarks2")
               ),
               PackagingType02(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeOfPackages = "originalTypeOfPackages3",
                 numberOfPackages = Some(300),
                 shippingMarks = Some("originalShippingMarks3")
               ),
               PackagingType02(
-                sequenceNumber = 4,
+                sequenceNumber = "4",
                 typeOfPackages = "originalTypeOfPackages4",
                 numberOfPackages = Some(400),
                 shippingMarks = Some("originalShippingMarks4")
               )
             )
             val ie043 = consignmentItem.copy(
-              goodsItemNumber = sequenceNumber,
+              goodsItemNumber = sequenceNumber.toString,
               Packaging = packaging
             )
 
@@ -2002,25 +2018,25 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
 
             result mustBe Seq(
               PackagingType04(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeOfPackages = Some("newTypeOfPackages1"),
                 numberOfPackages = None,
                 shippingMarks = None
               ),
               PackagingType04(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeOfPackages = None,
                 numberOfPackages = Some(2000),
                 shippingMarks = Some("newShippingMarks2")
               ),
               PackagingType04(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeOfPackages = None,
                 numberOfPackages = None,
                 shippingMarks = None
               ),
               PackagingType04(
-                sequenceNumber = 5,
+                sequenceNumber = "5",
                 typeOfPackages = Some("newTypeOfPackages5"),
                 numberOfPackages = Some(5000),
                 shippingMarks = Some("newShippingMarks5")
@@ -2034,20 +2050,20 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           consignmentItem =>
             val packaging = Seq(
               PackagingType02(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeOfPackages = "originalTypeOfPackages1",
                 numberOfPackages = Some(100),
                 shippingMarks = Some("originalShippingMarks1")
               ),
               PackagingType02(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeOfPackages = "originalTypeOfPackages2",
                 numberOfPackages = Some(200),
                 shippingMarks = Some("originalShippingMarks2")
               )
             )
             val ie043 = consignmentItem.copy(
-              goodsItemNumber = sequenceNumber,
+              goodsItemNumber = sequenceNumber.toString,
               Packaging = packaging
             )
 
@@ -2084,32 +2100,32 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           consignmentItem =>
             val supportingDocuments = Seq(
               SupportingDocumentType02(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = "originalTypeValue1",
                 referenceNumber = "originalReferenceNumber1",
                 complementOfInformation = Some("originalComplementOfInformation1")
               ),
               SupportingDocumentType02(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = "originalTypeValue2",
                 referenceNumber = "originalReferenceNumber2",
                 complementOfInformation = Some("originalComplementOfInformation2")
               ),
               SupportingDocumentType02(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeValue = "originalTypeValue3",
                 referenceNumber = "originalReferenceNumber3",
                 complementOfInformation = Some("originalComplementOfInformation3")
               ),
               SupportingDocumentType02(
-                sequenceNumber = 4,
+                sequenceNumber = "4",
                 typeValue = "originalTypeValue4",
                 referenceNumber = "originalReferenceNumber4",
                 complementOfInformation = Some("originalComplementOfInformation4")
               )
             )
             val ie043 = consignmentItem.copy(
-              goodsItemNumber = sequenceNumber,
+              goodsItemNumber = sequenceNumber.toString,
               SupportingDocument = supportingDocuments
             )
 
@@ -2148,25 +2164,25 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
 
             result mustBe Seq(
               SupportingDocumentType03(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = Some("newTypeValue1"),
                 referenceNumber = None,
                 complementOfInformation = None
               ),
               SupportingDocumentType03(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = None,
                 referenceNumber = Some("newReferenceNumber2"),
                 complementOfInformation = Some("newComplementOfInformation2")
               ),
               SupportingDocumentType03(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeValue = None,
                 referenceNumber = None,
                 complementOfInformation = None
               ),
               SupportingDocumentType03(
-                sequenceNumber = 5,
+                sequenceNumber = "5",
                 typeValue = Some("newTypeValue5"),
                 referenceNumber = Some("newReferenceNumber5"),
                 complementOfInformation = Some("newComplementOfInformation5")
@@ -2180,20 +2196,20 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           consignmentItem =>
             val supportingDocuments = Seq(
               SupportingDocumentType02(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = "originalTypeValue1",
                 referenceNumber = "originalReferenceNumber1",
                 complementOfInformation = Some("originalComplementOfInformation1")
               ),
               SupportingDocumentType02(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = "originalTypeValue2",
                 referenceNumber = "originalReferenceNumber2",
                 complementOfInformation = Some("originalComplementOfInformation2")
               )
             )
             val ie043 = consignmentItem.copy(
-              goodsItemNumber = sequenceNumber,
+              goodsItemNumber = sequenceNumber.toString,
               SupportingDocument = supportingDocuments
             )
 
@@ -2230,28 +2246,28 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           consignmentItem =>
             val transportDocuments = Seq(
               TransportDocumentType02(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = "originalTypeValue1",
                 referenceNumber = "originalReferenceNumber1"
               ),
               TransportDocumentType02(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = "originalTypeValue2",
                 referenceNumber = "originalReferenceNumber2"
               ),
               TransportDocumentType02(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeValue = "originalTypeValue3",
                 referenceNumber = "originalReferenceNumber3"
               ),
               TransportDocumentType02(
-                sequenceNumber = 4,
+                sequenceNumber = "4",
                 typeValue = "originalTypeValue4",
                 referenceNumber = "originalReferenceNumber4"
               )
             )
             val ie043 = consignmentItem.copy(
-              goodsItemNumber = sequenceNumber,
+              goodsItemNumber = sequenceNumber.toString,
               TransportDocument = transportDocuments
             )
 
@@ -2286,22 +2302,22 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
 
             result mustBe Seq(
               TransportDocumentType03(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = Some("newTypeValue1"),
                 referenceNumber = None
               ),
               TransportDocumentType03(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = None,
                 referenceNumber = Some("newReferenceNumber2")
               ),
               TransportDocumentType03(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeValue = None,
                 referenceNumber = None
               ),
               TransportDocumentType03(
-                sequenceNumber = 5,
+                sequenceNumber = "5",
                 typeValue = Some("newTypeValue5"),
                 referenceNumber = Some("newReferenceNumber5")
               )
@@ -2314,18 +2330,18 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           consignmentItem =>
             val transportDocuments = Seq(
               TransportDocumentType02(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = "originalTypeValue1",
                 referenceNumber = "originalReferenceNumber1"
               ),
               TransportDocumentType02(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = "originalTypeValue2",
                 referenceNumber = "originalReferenceNumber2"
               )
             )
             val ie043 = consignmentItem.copy(
-              goodsItemNumber = sequenceNumber,
+              goodsItemNumber = sequenceNumber.toString,
               TransportDocument = transportDocuments
             )
 
@@ -2360,28 +2376,28 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           consignmentItem =>
             val additionalReferences = Seq(
               AdditionalReferenceType02(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = "originalTypeValue1",
                 referenceNumber = Some("originalReferenceNumber1")
               ),
               AdditionalReferenceType02(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = "originalTypeValue2",
                 referenceNumber = Some("originalReferenceNumber2")
               ),
               AdditionalReferenceType02(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeValue = "originalTypeValue3",
                 referenceNumber = Some("originalReferenceNumber3")
               ),
               AdditionalReferenceType02(
-                sequenceNumber = 4,
+                sequenceNumber = "4",
                 typeValue = "originalTypeValue4",
                 referenceNumber = Some("originalReferenceNumber4")
               )
             )
             val ie043 = consignmentItem.copy(
-              goodsItemNumber = sequenceNumber,
+              goodsItemNumber = sequenceNumber.toString,
               AdditionalReference = additionalReferences
             )
 
@@ -2419,22 +2435,22 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
 
             result mustBe Seq(
               AdditionalReferenceType06(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = Some("newTypeValue1"),
                 referenceNumber = None
               ),
               AdditionalReferenceType06(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = None,
                 referenceNumber = Some("newReferenceNumber2")
               ),
               AdditionalReferenceType06(
-                sequenceNumber = 3,
+                sequenceNumber = "3",
                 typeValue = None,
                 referenceNumber = None
               ),
               AdditionalReferenceType06(
-                sequenceNumber = 5,
+                sequenceNumber = "5",
                 typeValue = Some("newTypeValue5"),
                 referenceNumber = Some("newReferenceNumber5")
               )
@@ -2447,18 +2463,18 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           consignmentItem =>
             val additionalReferences = Seq(
               AdditionalReferenceType02(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 typeValue = "originalTypeValue1",
                 referenceNumber = Some("originalReferenceNumber1")
               ),
               AdditionalReferenceType02(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 typeValue = "originalTypeValue2",
                 referenceNumber = Some("originalReferenceNumber2")
               )
             )
             val ie043 = consignmentItem.copy(
-              goodsItemNumber = sequenceNumber,
+              goodsItemNumber = sequenceNumber.toString,
               AdditionalReference = additionalReferences
             )
 

--- a/test/utils/answersHelpers/consignment/IncidentAnswersHelperSpec.scala
+++ b/test/utils/answersHelpers/consignment/IncidentAnswersHelperSpec.scala
@@ -399,26 +399,26 @@ class IncidentAnswersHelperSpec extends AnswersHelperSpecBase {
       "when there are transport equipment" - {
         "must return children" in {
           val transportEquipment = TransportEquipmentType07(
-            sequenceNumber = 1,
+            sequenceNumber = "1",
             containerIdentificationNumber = Some("cin"),
             numberOfSeals = Some(2),
             Seal = Seq(
               SealType04(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 identifier = "seal1"
               ),
               SealType04(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 identifier = "seal2"
               )
             ),
             GoodsReference = Seq(
               GoodsReferenceType01(
-                sequenceNumber = 1,
+                sequenceNumber = "1",
                 declarationGoodsItemNumber = 1
               ),
               GoodsReferenceType01(
-                sequenceNumber = 2,
+                sequenceNumber = "2",
                 declarationGoodsItemNumber = 2
               )
             )

--- a/test/utils/answersHelpers/consignment/IncidentTransportEquipmentAnswersHelperSpec.scala
+++ b/test/utils/answersHelpers/consignment/IncidentTransportEquipmentAnswersHelperSpec.scala
@@ -17,92 +17,91 @@
 package utils.answersHelpers.consignment
 
 import base.AppWithDefaultMockFixtures
-import generated.{GoodsReferenceType01, SealType04, TransportEquipmentType07}
-import models.UserAnswers
-import org.mockito.Mockito.when
-import play.api.inject.bind
-import play.api.inject.guice.GuiceApplicationBuilder
-import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import generated._
+import org.scalacheck.Arbitrary.arbitrary
 import utils.answersHelpers.AnswersHelperSpecBase
 import utils.answersHelpers.consignment.incident.IncidentTransportEquipmentAnswersHelper
 
 class IncidentTransportEquipmentAnswersHelperSpec extends AnswersHelperSpecBase with AppWithDefaultMockFixtures {
-
-  val mockUserAnswers: UserAnswers                         = mock[UserAnswers]
-  val mockTransportEquipmentType: TransportEquipmentType07 = mock[TransportEquipmentType07]
-
-  override def guiceApplicationBuilder(): GuiceApplicationBuilder =
-    super
-      .guiceApplicationBuilder()
-      .overrides(bind[TransportEquipmentType07].toInstance(mockTransportEquipmentType))
 
   "IncidentTransportEquipmentAnswersHelper" - {
 
     "containerIdentificationNumber" - {
 
       "must return None when containerIdentificationNumber undefined" in {
+        forAll(arbitrary[TransportEquipmentType07].map(_.copy(containerIdentificationNumber = None))) {
+          transportEquipment =>
+            val helper = new IncidentTransportEquipmentAnswersHelper(emptyUserAnswers, transportEquipment)
 
-        val helper =
-          new IncidentTransportEquipmentAnswersHelper(emptyUserAnswers,
-                                                      TransportEquipmentType07(1, None, None, Seq(SealType04(1, "1")), Seq(GoodsReferenceType01(1, 123)))
-          )
-        helper.containerIdentificationNumber mustBe None
+            val result = helper.containerIdentificationNumber
+
+            result mustBe None
+        }
       }
 
       "return a SummaryListRow for containerIdentificationNumber" in {
-        val helper: IncidentTransportEquipmentAnswersHelper = new IncidentTransportEquipmentAnswersHelper(mockUserAnswers, mockTransportEquipmentType)
-        when(mockTransportEquipmentType.containerIdentificationNumber).thenReturn(Some("Container123"))
+        val containerIdentificationNumber = "Container123"
 
-        val result: Option[SummaryListRow] = helper.containerIdentificationNumber
+        forAll(arbitrary[TransportEquipmentType07].map(_.copy(containerIdentificationNumber = Some(containerIdentificationNumber)))) {
+          transportEquipment =>
+            val helper = new IncidentTransportEquipmentAnswersHelper(emptyUserAnswers, transportEquipment)
 
-        result.isDefined mustBe true
-        result.get.value.content.value mustBe "Container123"
-        result.get.actions must not be defined
+            val result = helper.containerIdentificationNumber
 
+            result.isDefined mustBe true
+            result.get.value.content.value mustBe containerIdentificationNumber
+            result.get.actions must not be defined
+        }
       }
     }
 
     "transportEquipmentSeals" - {
       "must generate row for each seal" in {
+        val seals = Seq(SealType04("1", "Seal1"), SealType04("2", "Seal2"))
 
-        val helper: IncidentTransportEquipmentAnswersHelper = new IncidentTransportEquipmentAnswersHelper(mockUserAnswers, mockTransportEquipmentType)
-        when(mockTransportEquipmentType.Seal).thenReturn(Seq(SealType04(1, "Seal1"), SealType04(2, "Seal2")))
+        forAll(arbitrary[TransportEquipmentType07].map(_.copy(Seal = seals))) {
+          transportEquipment =>
+            val helper = new IncidentTransportEquipmentAnswersHelper(emptyUserAnswers, transportEquipment)
 
-        val result = helper.transportEquipmentSeals
+            val result = helper.transportEquipmentSeals
 
-        result.sectionTitle.value mustBe "Seals"
+            result.sectionTitle.value mustBe "Seals"
 
-        result.rows.size mustBe 2
+            result.rows.size mustBe 2
 
-        result.rows.head.key.value mustBe "Seal 1"
-        result.rows.head.value.value mustBe "Seal1"
-        result.rows.head.actions must not be defined
+            result.rows.head.key.value mustBe "Seal 1"
+            result.rows.head.value.value mustBe "Seal1"
+            result.rows.head.actions must not be defined
 
-        result.rows(1).key.value mustBe "Seal 2"
-        result.rows(1).value.value mustBe "Seal2"
-        result.rows(1).actions must not be defined
+            result.rows(1).key.value mustBe "Seal 2"
+            result.rows(1).value.value mustBe "Seal2"
+            result.rows(1).actions must not be defined
+        }
       }
     }
 
     "itemNumber" - {
       "must generate row for item" in {
+        val goodsReferences = Seq(GoodsReferenceType01("1", 123), GoodsReferenceType01("2", 234))
 
-        val helper: IncidentTransportEquipmentAnswersHelper = new IncidentTransportEquipmentAnswersHelper(mockUserAnswers, mockTransportEquipmentType)
-        when(mockTransportEquipmentType.GoodsReference).thenReturn(Seq(GoodsReferenceType01(1, 123), GoodsReferenceType01(2, 234)))
+        forAll(arbitrary[TransportEquipmentType07].map(_.copy(GoodsReference = goodsReferences))) {
+          transportEquipment =>
+            val helper = new IncidentTransportEquipmentAnswersHelper(emptyUserAnswers, transportEquipment)
 
-        val result = helper.itemNumbers
+            val result = helper.itemNumbers
 
-        result.sectionTitle.value mustBe "Goods item numbers"
+            result.sectionTitle.value mustBe "Goods item numbers"
 
-        result.rows.size mustBe 2
+            result.rows.size mustBe 2
 
-        result.rows.head.key.value mustBe "Goods item number 1"
-        result.rows.head.value.value mustBe "123"
-        result.rows.head.actions must not be defined
+            result.rows.head.key.value mustBe "Goods item number 1"
+            result.rows.head.value.value mustBe "123"
+            result.rows.head.actions must not be defined
 
-        result.rows(1).key.value mustBe "Goods item number 2"
-        result.rows(1).value.value mustBe "234"
-        result.rows(1).actions must not be defined
+            result.rows(1).key.value mustBe "Goods item number 2"
+            result.rows(1).value.value mustBe "234"
+            result.rows(1).actions must not be defined
+        }
       }
     }
   }

--- a/test/utils/transformers/DocumentsTransformerSpec.scala
+++ b/test/utils/transformers/DocumentsTransformerSpec.scala
@@ -56,13 +56,13 @@ class DocumentsTransformerSpec extends SpecBase with AppWithDefaultMockFixtures 
 
       val supportingDocuments = Seq(
         SupportingDocumentType02(
-          sequenceNumber = 1,
+          sequenceNumber = "1",
           typeValue = "sd1 tv",
           referenceNumber = "sd1 rn",
           complementOfInformation = Some("sd1 coi")
         ),
         SupportingDocumentType02(
-          sequenceNumber = 2,
+          sequenceNumber = "2",
           typeValue = "sd2 tv",
           referenceNumber = "sd2 rn",
           complementOfInformation = None
@@ -71,13 +71,13 @@ class DocumentsTransformerSpec extends SpecBase with AppWithDefaultMockFixtures 
 
       val previousDocuments = Seq(
         PreviousDocumentType06(
-          sequenceNumber = 1,
+          sequenceNumber = "1",
           typeValue = "pd1 tv",
           referenceNumber = "pd1 rn",
           complementOfInformation = Some("pd1 coi")
         ),
         PreviousDocumentType06(
-          sequenceNumber = 2,
+          sequenceNumber = "2",
           typeValue = "pd2 tv",
           referenceNumber = "pd2 rn",
           complementOfInformation = None
@@ -86,12 +86,12 @@ class DocumentsTransformerSpec extends SpecBase with AppWithDefaultMockFixtures 
 
       val transportDocuments = Seq(
         TransportDocumentType02(
-          sequenceNumber = 1,
+          sequenceNumber = "1",
           typeValue = "td1 tv",
           referenceNumber = "td1 rn"
         ),
         TransportDocumentType02(
-          sequenceNumber = 2,
+          sequenceNumber = "2",
           typeValue = "td2 tv",
           referenceNumber = "td2 rn"
         )
@@ -117,32 +117,32 @@ class DocumentsTransformerSpec extends SpecBase with AppWithDefaultMockFixtures 
 
       val result = transformer.transform(supportingDocuments, transportDocuments, previousDocuments).apply(emptyUserAnswers).futureValue
 
-      result.getSequenceNumber(DocumentSection(Index(0))) mustBe 1
+      result.getSequenceNumber(DocumentSection(Index(0))) mustBe "1"
       result.getValue(TypePage(Index(0))).toString mustBe "Supporting - (sd1 tv) sd1 d"
       result.getValue(DocumentReferenceNumberPage(Index(0))) mustBe "sd1 rn"
       result.getValue(AdditionalInformationPage(Index(0))) mustBe "sd1 coi"
 
-      result.getSequenceNumber(DocumentSection(Index(1))) mustBe 2
+      result.getSequenceNumber(DocumentSection(Index(1))) mustBe "2"
       result.getValue(TypePage(Index(1))).toString mustBe "Supporting - (sd2 tv) sd2 d"
       result.getValue(DocumentReferenceNumberPage(Index(1))) mustBe "sd2 rn"
       result.get(AdditionalInformationPage(Index(1))) must not be defined
 
-      result.getSequenceNumber(DocumentSection(Index(2))) mustBe 1
+      result.getSequenceNumber(DocumentSection(Index(2))) mustBe "1"
       result.getValue(TypePage(Index(2))).toString mustBe "Transport - (td1 tv) td1 d"
       result.getValue(DocumentReferenceNumberPage(Index(2))) mustBe "td1 rn"
       result.get(AdditionalInformationPage(Index(2))) must not be defined
 
-      result.getSequenceNumber(DocumentSection(Index(3))) mustBe 2
+      result.getSequenceNumber(DocumentSection(Index(3))) mustBe "2"
       result.getValue(TypePage(Index(3))).toString mustBe "Transport - (td2 tv) td2 d"
       result.getValue(DocumentReferenceNumberPage(Index(3))) mustBe "td2 rn"
       result.get(AdditionalInformationPage(Index(3))) must not be defined
 
-      result.getSequenceNumber(DocumentSection(Index(4))) mustBe 1
+      result.getSequenceNumber(DocumentSection(Index(4))) mustBe "1"
       result.getValue(TypePage(Index(4))).toString mustBe "Previous - (pd1 tv) pd1 d"
       result.getValue(DocumentReferenceNumberPage(Index(4))) mustBe "pd1 rn"
       result.getValue(AdditionalInformationPage(Index(4))) mustBe "pd1 coi"
 
-      result.getSequenceNumber(DocumentSection(Index(5))) mustBe 2
+      result.getSequenceNumber(DocumentSection(Index(5))) mustBe "2"
       result.getValue(TypePage(Index(5))).toString mustBe "Previous - (pd2 tv) pd2 d"
       result.getValue(DocumentReferenceNumberPage(Index(5))) mustBe "pd2 rn"
       result.get(AdditionalInformationPage(Index(5))) must not be defined
@@ -154,13 +154,13 @@ class DocumentsTransformerSpec extends SpecBase with AppWithDefaultMockFixtures 
 
       val supportingDocuments = Seq(
         SupportingDocumentType02(
-          sequenceNumber = 1,
+          sequenceNumber = "1",
           typeValue = "sd1 tv",
           referenceNumber = "sd1 rn",
           complementOfInformation = Some("sd1 coi")
         ),
         SupportingDocumentType02(
-          sequenceNumber = 2,
+          sequenceNumber = "2",
           typeValue = "sd2 tv",
           referenceNumber = "sd2 rn",
           complementOfInformation = None
@@ -169,12 +169,12 @@ class DocumentsTransformerSpec extends SpecBase with AppWithDefaultMockFixtures 
 
       val transportDocuments = Seq(
         TransportDocumentType02(
-          sequenceNumber = 1,
+          sequenceNumber = "1",
           typeValue = "td1 tv",
           referenceNumber = "td1 rn"
         ),
         TransportDocumentType02(
-          sequenceNumber = 2,
+          sequenceNumber = "2",
           typeValue = "td2 tv",
           referenceNumber = "td2 rn"
         )
@@ -182,13 +182,13 @@ class DocumentsTransformerSpec extends SpecBase with AppWithDefaultMockFixtures 
 
       val previousDocuments = Seq(
         PreviousDocumentType06(
-          sequenceNumber = 1,
+          sequenceNumber = "1",
           typeValue = "pd1 tv",
           referenceNumber = "pd1 rn",
           complementOfInformation = Some("pd1 coi")
         ),
         PreviousDocumentType06(
-          sequenceNumber = 2,
+          sequenceNumber = "2",
           typeValue = "pd2 tv",
           referenceNumber = "pd2 rn",
           complementOfInformation = None
@@ -215,22 +215,22 @@ class DocumentsTransformerSpec extends SpecBase with AppWithDefaultMockFixtures 
 
       val result = transformer.transform(supportingDocuments, transportDocuments, previousDocuments, hcIndex, itemIndex).apply(emptyUserAnswers).futureValue
 
-      result.getSequenceNumber(DocumentSection(hcIndex, itemIndex, Index(0))) mustBe 1
+      result.getSequenceNumber(DocumentSection(hcIndex, itemIndex, Index(0))) mustBe "1"
       result.getValue(DocumentReferenceNumberPage(hcIndex, itemIndex, Index(0))) mustBe "sd1 rn"
       result.getValue(AdditionalInformationPage(hcIndex, itemIndex, Index(0))) mustBe "sd1 coi"
       result.getValue(TypePage(hcIndex, itemIndex, Index(0))).toString mustBe "Supporting - (sd1 tv) sd1 d"
 
-      result.getSequenceNumber(DocumentSection(hcIndex, itemIndex, Index(1))) mustBe 2
+      result.getSequenceNumber(DocumentSection(hcIndex, itemIndex, Index(1))) mustBe "2"
       result.getValue(DocumentReferenceNumberPage(hcIndex, itemIndex, Index(1))) mustBe "sd2 rn"
       result.get(AdditionalInformationPage(hcIndex, itemIndex, Index(1))) must not be defined
       result.getValue(TypePage(hcIndex, itemIndex, Index(1))).toString mustBe "Supporting - (sd2 tv) sd2 d"
 
-      result.getSequenceNumber(DocumentSection(hcIndex, itemIndex, Index(2))) mustBe 1
+      result.getSequenceNumber(DocumentSection(hcIndex, itemIndex, Index(2))) mustBe "1"
       result.getValue(DocumentReferenceNumberPage(hcIndex, itemIndex, Index(2))) mustBe "td1 rn"
       result.get(AdditionalInformationPage(hcIndex, itemIndex, Index(2))) must not be defined
       result.getValue(TypePage(hcIndex, itemIndex, Index(2))).toString mustBe "Transport - (td1 tv) td1 d"
 
-      result.getSequenceNumber(DocumentSection(hcIndex, itemIndex, Index(3))) mustBe 2
+      result.getSequenceNumber(DocumentSection(hcIndex, itemIndex, Index(3))) mustBe "2"
       result.getValue(DocumentReferenceNumberPage(hcIndex, itemIndex, Index(3))) mustBe "td2 rn"
       result.get(AdditionalInformationPage(hcIndex, itemIndex, Index(3))) must not be defined
       result.getValue(TypePage(hcIndex, itemIndex, Index(3))).toString mustBe "Transport - (td2 tv) td2 d"
@@ -250,13 +250,13 @@ class DocumentsTransformerSpec extends SpecBase with AppWithDefaultMockFixtures 
 
       val supportingDocuments = Seq(
         SupportingDocumentType02(
-          sequenceNumber = 1,
+          sequenceNumber = "1",
           typeValue = "sd1 tv",
           referenceNumber = "sd1 rn",
           complementOfInformation = Some("sd1 coi")
         ),
         SupportingDocumentType02(
-          sequenceNumber = 2,
+          sequenceNumber = "2",
           typeValue = "sd2 tv",
           referenceNumber = "sd2 rn",
           complementOfInformation = None
@@ -265,12 +265,12 @@ class DocumentsTransformerSpec extends SpecBase with AppWithDefaultMockFixtures 
 
       val transportDocuments = Seq(
         TransportDocumentType02(
-          sequenceNumber = 1,
+          sequenceNumber = "1",
           typeValue = "td1 tv",
           referenceNumber = "td1 rn"
         ),
         TransportDocumentType02(
-          sequenceNumber = 2,
+          sequenceNumber = "2",
           typeValue = "td2 tv",
           referenceNumber = "td2 rn"
         )
@@ -278,13 +278,13 @@ class DocumentsTransformerSpec extends SpecBase with AppWithDefaultMockFixtures 
 
       val previousDocuments = Seq(
         PreviousDocumentType06(
-          sequenceNumber = 1,
+          sequenceNumber = "1",
           typeValue = "pd1 tv",
           referenceNumber = "pd1 rn",
           complementOfInformation = Some("pd1 coi")
         ),
         PreviousDocumentType06(
-          sequenceNumber = 2,
+          sequenceNumber = "2",
           typeValue = "pd2 tv",
           referenceNumber = "pd2 rn",
           complementOfInformation = None
@@ -311,22 +311,22 @@ class DocumentsTransformerSpec extends SpecBase with AppWithDefaultMockFixtures 
 
       val result = transformer.transform(supportingDocuments, transportDocuments, previousDocuments, hcIndex).apply(emptyUserAnswers).futureValue
 
-      result.getSequenceNumber(DocumentSection(hcIndex, Index(0))) mustBe 1
+      result.getSequenceNumber(DocumentSection(hcIndex, Index(0))) mustBe "1"
       result.getValue(DocumentReferenceNumberPage(hcIndex, Index(0))) mustBe "sd1 rn"
       result.getValue(AdditionalInformationPage(hcIndex, Index(0))) mustBe "sd1 coi"
       result.getValue(TypePage(hcIndex, Index(0))).toString mustBe "Supporting - (sd1 tv) sd1 d"
 
-      result.getSequenceNumber(DocumentSection(hcIndex, Index(1))) mustBe 2
+      result.getSequenceNumber(DocumentSection(hcIndex, Index(1))) mustBe "2"
       result.getValue(DocumentReferenceNumberPage(hcIndex, Index(1))) mustBe "sd2 rn"
       result.get(AdditionalInformationPage(hcIndex, Index(1))) must not be defined
       result.getValue(TypePage(hcIndex, Index(1))).toString mustBe "Supporting - (sd2 tv) sd2 d"
 
-      result.getSequenceNumber(DocumentSection(hcIndex, Index(2))) mustBe 1
+      result.getSequenceNumber(DocumentSection(hcIndex, Index(2))) mustBe "1"
       result.getValue(DocumentReferenceNumberPage(hcIndex, Index(2))) mustBe "td1 rn"
       result.get(AdditionalInformationPage(hcIndex, Index(2))) must not be defined
       result.getValue(TypePage(hcIndex, Index(2))).toString mustBe "Transport - (td1 tv) td1 d"
 
-      result.getSequenceNumber(DocumentSection(hcIndex, Index(3))) mustBe 2
+      result.getSequenceNumber(DocumentSection(hcIndex, Index(3))) mustBe "2"
       result.getValue(DocumentReferenceNumberPage(hcIndex, Index(3))) mustBe "td2 rn"
       result.get(AdditionalInformationPage(hcIndex, Index(3))) must not be defined
       result.getValue(TypePage(hcIndex, Index(3))).toString mustBe "Transport - (td2 tv) td2 d"

--- a/test/utils/transformers/GoodsMeasureTransformerSpec.scala
+++ b/test/utils/transformers/GoodsMeasureTransformerSpec.scala
@@ -31,11 +31,18 @@ class GoodsMeasureTransformerSpec extends SpecBase with AppWithDefaultMockFixtur
     "when goods measure defined" in {
       forAll(arbitrary[GoodsMeasureType03]) {
         goodsMeasure =>
-          val result = transformer.transform(goodsMeasure, hcIndex, itemIndex).apply(emptyUserAnswers).futureValue
+          val result = transformer.transform(Some(goodsMeasure), hcIndex, itemIndex).apply(emptyUserAnswers).futureValue
 
           result.getValue(GrossWeightPage(hcIndex, itemIndex)) mustBe goodsMeasure.grossMass
           result.get(NetWeightPage(hcIndex, itemIndex)) mustBe goodsMeasure.netMass
       }
+    }
+
+    "when goods measure undefined" in {
+      val result = transformer.transform(None, hcIndex, itemIndex).apply(emptyUserAnswers).futureValue
+
+      result.get(GrossWeightPage(hcIndex, itemIndex)) must not be defined
+      result.get(NetWeightPage(hcIndex, itemIndex)) must not be defined
     }
   }
 }

--- a/test/views/transportEquipment/index/GoodsReferenceViewSpec.scala
+++ b/test/views/transportEquipment/index/GoodsReferenceViewSpec.scala
@@ -35,7 +35,7 @@ class GoodsReferenceViewSpec extends InputSelectViewBehaviours[GoodsReference] {
   val ie043Answers: CC043CType = emptyUserAnswers.ie043Data.copy(Consignment =
     Some(
       ConsignmentType05(
-        TransportEquipment = Seq(TransportEquipmentType05(1, None, 0, Nil, Seq(GoodsReferenceType02(1, 123)))),
+        TransportEquipment = Seq(TransportEquipmentType05("1", None, 0, Nil, Seq(GoodsReferenceType02("1", 123)))),
         containerIndicator = arbitraryFlag.arbitrary.sample.get
       )
     )


### PR DESCRIPTION
- When we go live we need the RFC37 XSDs to be used across all of our services
- The main differences between RFC37 and RFC39 with regards to this journey are:
  - sequence numbers are of type String in RFC 37 and type BigInt in RFC39
  - GoodsMeasure is required in RFC39 and optional in RFC37
  - House consignment country of destination is not included in RFC37 but is in RFC39. This has been manually added as an optional to our XSD so we do not need to remove the transformer code