### PR TITLE
Content fix for error message

### DIFF
--- a/conf/messages.en
+++ b/conf/messages.en
@@ -307,7 +307,7 @@ unloadingType.checkYourAnswers = Have you fully or partially unloaded the goods?
 unloadingType.checkYourAnswersLabel = Are any of the seals broken?
 unloadingType.1 = Fully unloaded
 unloadingType.0 = Partially unloaded
-unloadingType.error.required = Select whether you have fully or partially unloaded the goods
+unloadingType.NormalMode.error.required = Select whether you have fully or partially unloaded the goods
 unloadingType.checkYourAnswers.change.hidden = whether you fully or partially unloaded the goods
 
 areAnySealsBroken.title = Are any of the seals broken?

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -308,6 +308,7 @@ unloadingType.checkYourAnswersLabel = Are any of the seals broken?
 unloadingType.1 = Fully unloaded
 unloadingType.0 = Partially unloaded
 unloadingType.NormalMode.error.required = Select whether you have fully or partially unloaded the goods
+unloadingType.CheckMode.error.required = Select whether you have fully or partially unloaded the goods
 unloadingType.checkYourAnswers.change.hidden = whether you fully or partially unloaded the goods
 
 areAnySealsBroken.title = Are any of the seals broken?


### PR DESCRIPTION
Screenshots showing NormalMode and CheckMode error message is now correct

![Screenshot from 2024-07-03 10-41-41](https://github.com/hmrc/manage-transit-movements-unloading-frontend/assets/31237148/b791c807-439c-4260-94f3-1f4a00067420)
![Screenshot from 2024-07-03 10-42-01](https://github.com/hmrc/manage-transit-movements-unloading-frontend/assets/31237148/65d57147-3393-469b-88e0-23c159f874ce)


![Screenshot from 2024-07-03 09-27-11](https://github.com/hmrc/manage-transit-movements-unloading-frontend/assets/31237148/d60c349f-6a05-47de-8a70-fefed00e92ed)
