### PR TITLE
CTCP-5727: Ensuring any message type can be read.

### DIFF
--- a/app/models/P5/ArrivalMessageType.scala
+++ b/app/models/P5/ArrivalMessageType.scala
@@ -16,32 +16,44 @@
 
 package models.P5
 
-import models.{Enumerable, WithName}
+import play.api.libs.json.{__, Reads}
 
-trait ArrivalMessageType extends WithName
+trait ArrivalMessageType {
+  val value: String
 
-trait ErrorMessageType extends ArrivalMessageType
+  override def toString: String = value
+}
 
-object ArrivalMessageType extends Enumerable.Implicits {
+object ArrivalMessageType {
 
-  case object ArrivalNotification extends WithName("IE007") with ArrivalMessageType
-  case object UnloadingRemarks extends WithName("IE044") with ArrivalMessageType
-  case object GoodsReleasedNotification extends WithName("IE025") with ArrivalMessageType
-  case object UnloadingPermission extends WithName("IE043") with ArrivalMessageType
-  case object RejectionFromOfficeOfDestination extends WithName("IE057") with ArrivalMessageType
+  case object ArrivalNotification extends ArrivalMessageType {
+    override val value: String = "IE007"
+  }
 
-  val values = Seq(
-    ArrivalNotification,
-    UnloadingRemarks,
-    GoodsReleasedNotification,
-    UnloadingPermission,
-    RejectionFromOfficeOfDestination
-  )
+  case object GoodsReleasedNotification extends ArrivalMessageType {
+    override val value: String = "IE025"
+  }
 
-  implicit val enumerable: Enumerable[ArrivalMessageType] =
-    Enumerable(
-      values.map(
-        v => v.toString -> v
-      ): _*
-    )
+  case object UnloadingPermission extends ArrivalMessageType {
+    override val value: String = "IE043"
+  }
+
+  case object UnloadingRemarks extends ArrivalMessageType {
+    override val value: String = "IE044"
+  }
+
+  case object RejectionFromOfficeOfDestination extends ArrivalMessageType {
+    override val value: String = "IE057"
+  }
+
+  case class Other(value: String) extends ArrivalMessageType
+
+  implicit val reads: Reads[ArrivalMessageType] = __.read[String].map {
+    case ArrivalNotification.value              => ArrivalNotification
+    case GoodsReleasedNotification.value        => GoodsReleasedNotification
+    case UnloadingPermission.value              => UnloadingPermission
+    case UnloadingRemarks.value                 => UnloadingRemarks
+    case RejectionFromOfficeOfDestination.value => RejectionFromOfficeOfDestination
+    case value                                  => Other(value)
+  }
 }

--- a/test/generators/ModelGenerators.scala
+++ b/test/generators/ModelGenerators.scala
@@ -119,10 +119,22 @@ trait ModelGenerators {
       Gen.oneOf(UnloadingType.values)
     }
 
-  implicit lazy val arbitraryArrivalMessageType: Arbitrary[ArrivalMessageType] =
+  implicit lazy val arbitraryArrivalMessageType: Arbitrary[ArrivalMessageType] = {
+    import models.P5.ArrivalMessageType._
     Arbitrary {
-      Gen.oneOf(ArrivalMessageType.values)
+      for {
+        value <- nonEmptyString
+        result <- Gen.oneOf(
+          ArrivalNotification,
+          GoodsReleasedNotification,
+          UnloadingPermission,
+          UnloadingRemarks,
+          RejectionFromOfficeOfDestination,
+          Other(value)
+        )
+      } yield result
     }
+  }
 
   implicit lazy val arbitraryCountry: Arbitrary[Country] =
     Arbitrary {

--- a/test/models/P5/ArrivalMessageTypeSpec.scala
+++ b/test/models/P5/ArrivalMessageTypeSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.P5
+
+import base.SpecBase
+import generators.Generators
+import models.P5.ArrivalMessageType._
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import play.api.libs.json.{JsError, JsString, Json}
+
+class ArrivalMessageTypeSpec extends SpecBase with ScalaCheckPropertyChecks with Generators {
+
+  "ArrivalMessageType" - {
+    "must deserialise" - {
+      "when a JsString" - {
+        "when IE007" in {
+          val result = JsString("IE007").as[ArrivalMessageType]
+          result mustBe ArrivalNotification
+        }
+
+        "when IE025" in {
+          val result = JsString("IE025").as[ArrivalMessageType]
+          result mustBe GoodsReleasedNotification
+        }
+
+        "when IE043" in {
+          val result = JsString("IE043").as[ArrivalMessageType]
+          result mustBe UnloadingPermission
+        }
+
+        "when IE044" in {
+          val result = JsString("IE044").as[ArrivalMessageType]
+          result mustBe UnloadingRemarks
+        }
+
+        "when IE057" in {
+          val result = JsString("IE057").as[ArrivalMessageType]
+          result mustBe RejectionFromOfficeOfDestination
+        }
+
+        "when something else" in {
+          forAll(nonEmptyString) {
+            value =>
+              val result = JsString(value).as[ArrivalMessageType]
+              result mustBe Other(value)
+          }
+        }
+      }
+    }
+
+    "must fail to deserialise" - {
+      "when not a JsString" - {
+        val result = Json.obj("foo" -> "bar").validate[ArrivalMessageType]
+        result mustBe a[JsError]
+      }
+    }
+  }
+}

--- a/test/models/P5/MessageMetaDataSpec.scala
+++ b/test/models/P5/MessageMetaDataSpec.scala
@@ -17,18 +17,21 @@
 package models.P5
 
 import base.SpecBase
+import generators.Generators
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.libs.json.Json
 
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import org.scalacheck.Arbitrary.arbitrary
 
-class MessageMetaDataSpec extends SpecBase {
+class MessageMetaDataSpec extends SpecBase with ScalaCheckPropertyChecks with Generators {
 
   "MessageMetaData" - {
 
     "must deserialize" in {
 
-      ArrivalMessageType.values.map {
+      forAll(arbitrary[ArrivalMessageType]) {
         messageType =>
           val json = Json.parse(
             s"""


### PR DESCRIPTION
To fix the issue
> uk.gov.hmrc.http.JsValidationException: GET of 'https://common-transit-convention-traders.protected.mdtp:443/movements/arrivals/669a1f7a563ea8ff/messages' returned invalid json. Attempting to convert to models.P5.Messages gave errors: List((/messages(0)/type,List(JsonValidationError(List(error.invalid),List()))))