### PR TITLE
CTCP-5800: Replaced getMessageHead with canSubmitUnloadingRemarks.

### DIFF
--- a/app/controllers/actions/CheckArrivalStatusAction.scala
+++ b/app/controllers/actions/CheckArrivalStatusAction.scala
@@ -17,7 +17,6 @@
 package controllers.actions
 
 import models.ArrivalId
-import models.P5.ArrivalMessageType.UnloadingPermission
 import models.requests.IdentifierRequest
 import play.api.mvc.Results.Redirect
 import play.api.mvc.{ActionFilter, Result}
@@ -43,14 +42,9 @@ class ArrivalStatusAction(
   override protected def filter[A](request: IdentifierRequest[A]): Future[Option[Result]] = {
 
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
-    unloadingPermissionMessageService.getMessageHead(arrivalId).map {
-      case Some(messageMetaData) =>
-        messageMetaData.messageType match {
-          case UnloadingPermission => None
-          case _                   => Option(Redirect(controllers.routes.CannotSendUnloadingRemarksController.onPageLoad(arrivalId)))
-        }
-      case _ => Option(Redirect(controllers.routes.CannotSendUnloadingRemarksController.onPageLoad(arrivalId)))
-
+    unloadingPermissionMessageService.canSubmitUnloadingRemarks(arrivalId).map {
+      case true  => None
+      case false => Option(Redirect(controllers.routes.CannotSendUnloadingRemarksController.onPageLoad(arrivalId)))
     }
   }
 

--- a/test/base/AppWithDefaultMockFixtures.scala
+++ b/test/base/AppWithDefaultMockFixtures.scala
@@ -18,8 +18,6 @@ package base
 
 import config.{PostTransitionModule, TransitionModule}
 import controllers.actions._
-import models.P5.ArrivalMessageType.UnloadingPermission
-import models.P5._
 import models.{Mode, UserAnswers}
 import navigation.SealNavigator.SealNavigatorProvider
 import navigation._
@@ -36,7 +34,6 @@ import play.api.mvc.Call
 import repositories.SessionRepository
 import services.P5.UnloadingPermissionMessageService
 
-import java.time.LocalDateTime
 import scala.concurrent.Future
 
 trait AppWithDefaultMockFixtures extends BeforeAndAfterEach with GuiceOneAppPerSuite with GuiceFakeApplicationFactory with MockitoSugar {
@@ -47,8 +44,8 @@ trait AppWithDefaultMockFixtures extends BeforeAndAfterEach with GuiceOneAppPerS
     reset(mockDataRetrievalActionProvider)
     reset(mockUnloadingPermissionMessageService)
 
-    when(mockUnloadingPermissionMessageService.getMessageHead(any())(any(), any()))
-      .thenReturn(Future.successful(Some(MessageMetaData(LocalDateTime.now(), UnloadingPermission, "foo/bar"))))
+    when(mockUnloadingPermissionMessageService.canSubmitUnloadingRemarks(any())(any(), any()))
+      .thenReturn(Future.successful(true))
 
     when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
   }

--- a/test/controllers/UnloadingFindingsControllerSpec.scala
+++ b/test/controllers/UnloadingFindingsControllerSpec.scala
@@ -19,8 +19,6 @@ package controllers
 import base.{AppWithDefaultMockFixtures, SpecBase}
 import generators.Generators
 import models.NormalMode
-import models.P5.ArrivalMessageType.UnloadingPermission
-import models.P5.MessageMetaData
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -31,9 +29,6 @@ import play.api.test.Helpers._
 import viewModels.UnloadingFindingsViewModel
 import viewModels.UnloadingFindingsViewModel.UnloadingFindingsViewModelProvider
 import views.html.UnloadingFindingsView
-
-import java.time.LocalDateTime
-import scala.concurrent.Future
 
 class UnloadingFindingsControllerSpec extends SpecBase with AppWithDefaultMockFixtures with ScalaCheckPropertyChecks with Generators {
 
@@ -50,11 +45,6 @@ class UnloadingFindingsControllerSpec extends SpecBase with AppWithDefaultMockFi
 
     "must return OK and the correct view for a GET" in {
       checkArrivalStatus()
-      when(
-        mockUnloadingPermissionMessageService
-          .getMessageHead(any())(any(), any())
-      )
-        .thenReturn(Future.successful(Some(MessageMetaData(LocalDateTime.now(), UnloadingPermission, ""))))
 
       setExistingUserAnswers(emptyUserAnswers)
 

--- a/test/controllers/actions/ArrivalStatusActionSpec.scala
+++ b/test/controllers/actions/ArrivalStatusActionSpec.scala
@@ -19,19 +19,15 @@ package controllers.actions
 import base.{AppWithDefaultMockFixtures, SpecBase}
 import generators.Generators
 import models.EoriNumber
-import models.P5.ArrivalMessageType.UnloadingPermission
-import models.P5.{ArrivalMessageType, MessageMetaData}
 import models.requests.IdentifierRequest
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import org.scalacheck.Arbitrary.arbitrary
 import org.scalatest.BeforeAndAfterEach
 import play.api.mvc.Results._
 import play.api.mvc._
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 
-import java.time.LocalDateTime
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
@@ -42,6 +38,9 @@ class ArrivalStatusActionSpec extends SpecBase with BeforeAndAfterEach with Gene
 
   "ArrivalStatusAction" - {
     "must return None when an unloading permission is available" in {
+
+      when(mockUnloadingPermissionMessageService.canSubmitUnloadingRemarks(any())(any(), any()))
+        .thenReturn(Future.successful(true))
 
       val checkArrivalStatusProvider = new CheckArrivalStatusProvider(mockUnloadingPermissionMessageService)
 
@@ -54,9 +53,8 @@ class ArrivalStatusActionSpec extends SpecBase with BeforeAndAfterEach with Gene
 
     "must return 303 and redirect to CannotSendUnloadingRemarks when no unloading permission is available" in {
 
-      val messageType = arbitrary[ArrivalMessageType].retryUntil(_ != UnloadingPermission).sample.value
-      when(mockUnloadingPermissionMessageService.getMessageHead(any())(any(), any()))
-        .thenReturn(Future.successful(Some(MessageMetaData(LocalDateTime.now(), messageType, ""))))
+      when(mockUnloadingPermissionMessageService.canSubmitUnloadingRemarks(any())(any(), any()))
+        .thenReturn(Future.successful(false))
 
       val checkArrivalStatusProvider = new CheckArrivalStatusProvider(mockUnloadingPermissionMessageService)
 

--- a/test/controllers/houseConsignment/index/items/NetWeightControllerSpec.scala
+++ b/test/controllers/houseConsignment/index/items/NetWeightControllerSpec.scala
@@ -20,8 +20,6 @@ import base.{AppWithDefaultMockFixtures, SpecBase}
 import forms.WeightFormProvider
 import generators.Generators
 import models.NormalMode
-import models.P5.ArrivalMessageType.UnloadingPermission
-import models.P5.{ArrivalMessageType, MessageMetaData}
 import navigation.houseConsignment.index.items.HouseConsignmentItemNavigator.HouseConsignmentItemNavigatorProvider
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -35,7 +33,6 @@ import viewModels.houseConsignment.index.items.NetWeightViewModel
 import viewModels.houseConsignment.index.items.NetWeightViewModel.NetWeightViewModelProvider
 import views.html.houseConsignment.index.items.NetWeightView
 
-import java.time.LocalDateTime
 import scala.concurrent.Future
 
 class NetWeightControllerSpec extends SpecBase with AppWithDefaultMockFixtures with Generators {
@@ -193,9 +190,9 @@ class NetWeightControllerSpec extends SpecBase with AppWithDefaultMockFixtures w
 
     "return OK and the correct view for a GET when message is not Unloading Permission(IE043)" in {
       checkArrivalStatus()
-      val messageType = arbitrary[ArrivalMessageType].retryUntil(_ != UnloadingPermission).sample.value
-      when(mockUnloadingPermissionMessageService.getMessageHead(any())(any(), any()))
-        .thenReturn(Future.successful(Some(MessageMetaData(LocalDateTime.now(), messageType, ""))))
+
+      when(mockUnloadingPermissionMessageService.canSubmitUnloadingRemarks(any())(any(), any()))
+        .thenReturn(Future.successful(false))
 
       setExistingUserAnswers(emptyUserAnswers)
 


### PR DESCRIPTION
User can submit unloading remarks in the following scenarios:

- IE007 -> IE043
- IE007 -> IE043 -> IE044 -> IE057
- IE007 -> IE043 -> IE044 -> IE057 -> IE044 -> IE057 ...
- IE007 -> IE057 -> IE007 -> ... -> IE043