### PR TITLE
CTCP-6435

### DIFF
--- a/app/pages/UniqueConsignmentReferencePage.scala
+++ b/app/pages/UniqueConsignmentReferencePage.scala
@@ -26,7 +26,6 @@ case object UniqueConsignmentReferencePage extends DiscrepancyQuestionPage[Strin
 
   override def toString: String = "ucr"
 
-  // TODO - update in CTCP-6435
   override def valueInIE043(ie043: Option[ConsignmentType05], sequenceNumber: Option[BigInt]): Option[String] =
-    None
+    ie043.flatMap(_.referenceNumberUCR)
 }

--- a/app/pages/countriesOfRouting/CountryOfRoutingPage.scala
+++ b/app/pages/countriesOfRouting/CountryOfRoutingPage.scala
@@ -16,20 +16,23 @@
 
 package pages.countriesOfRouting
 
-import generated.ConsignmentType05
+import generated.CountryOfRoutingOfConsignmentType02
 import models.Index
 import models.reference.Country
 import pages.DiscrepancyQuestionPage
 import pages.sections.CountryOfRoutingSection
 import play.api.libs.json.JsPath
 
-case class CountryOfRoutingPage(countryIndex: Index) extends DiscrepancyQuestionPage[Country, Option[ConsignmentType05], String] {
+case class CountryOfRoutingPage(countryIndex: Index) extends DiscrepancyQuestionPage[Country, Seq[CountryOfRoutingOfConsignmentType02], String] {
 
   override def path: JsPath = CountryOfRoutingSection(countryIndex).path \ toString
 
   override def toString: String = "country"
 
-  // TODO - update in CTCP-6435
-  override def valueInIE043(ie043: Option[ConsignmentType05], sequenceNumber: Option[BigInt]): Option[String] =
-    None
+  override def valueInIE043(ie043: Seq[CountryOfRoutingOfConsignmentType02], sequenceNumber: Option[BigInt]): Option[String] =
+    ie043
+      .find {
+        x => sequenceNumber.contains(x.sequenceNumber)
+      }
+      .map(_.country)
 }

--- a/app/pages/houseConsignment/index/GrossWeightPage.scala
+++ b/app/pages/houseConsignment/index/GrossWeightPage.scala
@@ -22,16 +22,12 @@ import pages.DiscrepancyQuestionPage
 import pages.sections.HouseConsignmentSection
 import play.api.libs.json.JsPath
 
-case class GrossWeightPage(houseConsignmentIndex: Index) extends DiscrepancyQuestionPage[BigDecimal, Seq[HouseConsignmentType04], BigDecimal] {
+case class GrossWeightPage(houseConsignmentIndex: Index) extends DiscrepancyQuestionPage[BigDecimal, Option[HouseConsignmentType04], BigDecimal] {
 
   override def path: JsPath = HouseConsignmentSection(houseConsignmentIndex).path \ toString
 
   override def toString: String = "grossMass"
 
-  override def valueInIE043(ie043: Seq[HouseConsignmentType04], sequenceNumber: Option[BigInt]): Option[BigDecimal] =
-    ie043
-      .find {
-        x => sequenceNumber.contains(x.sequenceNumber)
-      }
-      .map(_.grossMass)
+  override def valueInIE043(ie043: Option[HouseConsignmentType04], sequenceNumber: Option[BigInt]): Option[BigDecimal] =
+    ie043.map(_.grossMass)
 }

--- a/app/pages/houseConsignment/index/UniqueConsignmentReferencePage.scala
+++ b/app/pages/houseConsignment/index/UniqueConsignmentReferencePage.scala
@@ -22,13 +22,12 @@ import pages.DiscrepancyQuestionPage
 import pages.sections.HouseConsignmentSection
 import play.api.libs.json.JsPath
 
-case class UniqueConsignmentReferencePage(houseConsignmentIndex: Index) extends DiscrepancyQuestionPage[String, Seq[HouseConsignmentType04], String] {
+case class UniqueConsignmentReferencePage(houseConsignmentIndex: Index) extends DiscrepancyQuestionPage[String, Option[HouseConsignmentType04], String] {
 
   override def path: JsPath = HouseConsignmentSection(houseConsignmentIndex).path \ toString
 
   override def toString: String = "ucr"
 
-  // TODO - update in CTCP-6435
-  override def valueInIE043(ie043: Seq[HouseConsignmentType04], sequenceNumber: Option[BigInt]): Option[String] =
-    None
+  override def valueInIE043(ie043: Option[HouseConsignmentType04], sequenceNumber: Option[BigInt]): Option[String] =
+    ie043.flatMap(_.referenceNumberUCR)
 }

--- a/app/pages/houseConsignment/index/items/UniqueConsignmentReferencePage.scala
+++ b/app/pages/houseConsignment/index/items/UniqueConsignmentReferencePage.scala
@@ -16,21 +16,19 @@
 
 package pages.houseConsignment.index.items
 
-import generated.HouseConsignmentType04
+import generated.ConsignmentItemType04
 import models.Index
 import pages.DiscrepancyQuestionPage
 import pages.sections.ItemSection
 import play.api.libs.json.JsPath
 
 case class UniqueConsignmentReferencePage(houseConsignmentIndex: Index, itemIndex: Index)
-    extends DiscrepancyQuestionPage[String, Seq[HouseConsignmentType04], String] {
+    extends DiscrepancyQuestionPage[String, Option[ConsignmentItemType04], String] {
 
   override def path: JsPath = ItemSection(houseConsignmentIndex, itemIndex).path \ toString
 
   override def toString: String = "ucr"
 
-  // TODO - update in CTCP-6435
-  override def valueInIE043(ie043: Seq[HouseConsignmentType04], sequenceNumber: Option[BigInt]): Option[String] =
-    None
-
+  override def valueInIE043(ie043: Option[ConsignmentItemType04], sequenceNumber: Option[BigInt]): Option[String] =
+    ie043.flatMap(_.referenceNumberUCR)
 }

--- a/test/base/AppWithDefaultMockFixtures.scala
+++ b/test/base/AppWithDefaultMockFixtures.scala
@@ -173,4 +173,10 @@ trait AppWithDefaultMockFixtures extends BeforeAndAfterEach with GuiceOneAppPerS
 
   protected def guiceApplicationBuilder(): GuiceApplicationBuilder =
     defaultApplicationBuilder()
+
+  def phase5App: GuiceApplicationBuilder => GuiceApplicationBuilder =
+    _ => guiceApplicationBuilder().configure("feature-flags.phase-6-enabled" -> false)
+
+  def phase6App: GuiceApplicationBuilder => GuiceApplicationBuilder =
+    _ => guiceApplicationBuilder().configure("feature-flags.phase-6-enabled" -> true)
 }

--- a/test/services/submission/SubmissionServiceSpec.scala
+++ b/test/services/submission/SubmissionServiceSpec.scala
@@ -65,22 +65,22 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
   "attributes" - {
     "must assign phase ID" - {
       "when phase6 disabled" in {
-        val app = guiceApplicationBuilder().configure("feature-flags.phase-6-enabled" -> false).build()
-        running(app) {
-          val service = app.injector.instanceOf[SubmissionService]
-          val result  = service.attributes
-          result.keys.size mustEqual 1
-          result.get("@PhaseID").value.value.toString mustEqual "NCTS5.1"
+        running(phase5App) {
+          app =>
+            val service = app.injector.instanceOf[SubmissionService]
+            val result  = service.attributes
+            result.keys.size mustEqual 1
+            result.get("@PhaseID").value.value.toString mustEqual "NCTS5.1"
         }
       }
 
       "when phase6 enabled" in {
-        val app = guiceApplicationBuilder().configure("feature-flags.phase-6-enabled" -> true).build()
-        running(app) {
-          val service = app.injector.instanceOf[SubmissionService]
-          val result  = service.attributes
-          result.keys.size mustEqual 1
-          result.get("@PhaseID").value.value.toString mustEqual "NCTS6"
+        running(phase6App) {
+          app =>
+            val service = app.injector.instanceOf[SubmissionService]
+            val result  = service.attributes
+            result.keys.size mustEqual 1
+            result.get("@PhaseID").value.value.toString mustEqual "NCTS6"
         }
       }
     }
@@ -91,7 +91,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
       "when GB office of destination" in {
         val result = service.messageSequence(eoriNumber, "GB00001")
 
-        result mustBe MESSAGESequence(
+        result mustEqual MESSAGESequence(
           messageSender = eoriNumber.value,
           messageRecipient = "NTA.GB",
           preparationDateAndTime = XMLCalendar("2020-01-01T09:30:00"),
@@ -104,7 +104,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
       "when XI office of destination" in {
         val result = service.messageSequence(eoriNumber, "XI00001")
 
-        result mustBe MESSAGESequence(
+        result mustEqual MESSAGESequence(
           messageSender = eoriNumber.value,
           messageRecipient = "NTA.XI",
           preparationDateAndTime = XMLCalendar("2020-01-01T09:30:00"),
@@ -129,7 +129,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.transitOperationReads(userAnswers)
             val result = userAnswers.data.as[TransitOperationType11](reads)
 
-            result mustBe TransitOperationType11(
+            result mustEqual TransitOperationType11(
               MRN = userAnswers.mrn.value,
               otherThingsToReport = Some(otherThingsToReport)
             )
@@ -142,7 +142,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
         val reads  = service.transitOperationReads(userAnswers)
         val result = userAnswers.data.as[TransitOperationType11](reads)
 
-        result mustBe TransitOperationType11(
+        result mustEqual TransitOperationType11(
           MRN = userAnswers.mrn.value,
           otherThingsToReport = None
         )
@@ -183,7 +183,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
                 val reads  = service.unloadingRemarkReads(userAnswers)
                 val result = userAnswers.data.as[UnloadingRemarkType](reads)
 
-                result mustBe UnloadingRemarkType(
+                result mustEqual UnloadingRemarkType(
                   conform = Number1,
                   unloadingCompletion = Number1,
                   unloadingDate = XMLCalendar("2020-01-01"),
@@ -222,7 +222,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
                 val reads  = service.unloadingRemarkReads(userAnswers)
                 val result = userAnswers.data.as[UnloadingRemarkType](reads)
 
-                result mustBe UnloadingRemarkType(
+                result mustEqual UnloadingRemarkType(
                   conform = Number0,
                   unloadingCompletion = Number1,
                   unloadingDate = XMLCalendar("2020-01-01"),
@@ -262,7 +262,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
                 val reads  = service.unloadingRemarkReads(userAnswers)
                 val result = userAnswers.data.as[UnloadingRemarkType](reads)
 
-                result mustBe UnloadingRemarkType(
+                result mustEqual UnloadingRemarkType(
                   conform = Number0,
                   unloadingCompletion = Number1,
                   unloadingDate = XMLCalendar("2020-01-01"),
@@ -301,7 +301,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
                 val reads  = service.unloadingRemarkReads(userAnswers)
                 val result = userAnswers.data.as[UnloadingRemarkType](reads)
 
-                result mustBe UnloadingRemarkType(
+                result mustEqual UnloadingRemarkType(
                   conform = Number0,
                   unloadingCompletion = Number1,
                   unloadingDate = XMLCalendar("2020-01-01"),
@@ -341,7 +341,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
                 val reads  = service.unloadingRemarkReads(userAnswers)
                 val result = userAnswers.data.as[UnloadingRemarkType](reads)
 
-                result mustBe UnloadingRemarkType(
+                result mustEqual UnloadingRemarkType(
                   conform = Number1,
                   unloadingCompletion = Number1,
                   unloadingDate = XMLCalendar("2020-01-01"),
@@ -366,7 +366,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           val reads  = service.unloadingRemarkReads(userAnswers)
           val result = userAnswers.data.as[UnloadingRemarkType](reads)
 
-          result mustBe UnloadingRemarkType(
+          result mustEqual UnloadingRemarkType(
             conform = Number1,
             unloadingCompletion = Number1,
             unloadingDate = XMLCalendar("2020-01-01"),
@@ -395,7 +395,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
                   val reads  = service.unloadingRemarkReads(userAnswers)
                   val result = userAnswers.data.as[UnloadingRemarkType](reads)
 
-                  result mustBe UnloadingRemarkType(
+                  result mustEqual UnloadingRemarkType(
                     conform = Number0,
                     unloadingCompletion = Number1,
                     unloadingDate = XMLCalendar("2020-01-01"),
@@ -420,7 +420,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
                   val reads  = service.unloadingRemarkReads(userAnswers)
                   val result = userAnswers.data.as[UnloadingRemarkType](reads)
 
-                  result mustBe UnloadingRemarkType(
+                  result mustEqual UnloadingRemarkType(
                     conform = Number1,
                     unloadingCompletion = Number1,
                     unloadingDate = XMLCalendar("2020-01-01"),
@@ -445,7 +445,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
                 val reads  = service.unloadingRemarkReads(userAnswers)
                 val result = userAnswers.data.as[UnloadingRemarkType](reads)
 
-                result mustBe UnloadingRemarkType(
+                result mustEqual UnloadingRemarkType(
                   conform = Number0,
                   unloadingCompletion = Number1,
                   unloadingDate = XMLCalendar("2020-01-01"),
@@ -469,7 +469,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
                 val reads  = service.unloadingRemarkReads(userAnswers)
                 val result = userAnswers.data.as[UnloadingRemarkType](reads)
 
-                result mustBe UnloadingRemarkType(
+                result mustEqual UnloadingRemarkType(
                   conform = Number0,
                   unloadingCompletion = Number1,
                   unloadingDate = XMLCalendar("2020-01-01"),
@@ -493,7 +493,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
                 val reads  = service.unloadingRemarkReads(userAnswers)
                 val result = userAnswers.data.as[UnloadingRemarkType](reads)
 
-                result mustBe UnloadingRemarkType(
+                result mustEqual UnloadingRemarkType(
                   conform = Number0,
                   unloadingCompletion = Number1,
                   unloadingDate = XMLCalendar("2020-01-01"),
@@ -514,7 +514,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
               val reads  = service.unloadingRemarkReads(userAnswers)
               val result = userAnswers.data.as[UnloadingRemarkType](reads)
 
-              result mustBe UnloadingRemarkType(
+              result mustEqual UnloadingRemarkType(
                 conform = Number1,
                 unloadingCompletion = Number0,
                 unloadingDate = XMLCalendar("2020-01-01"),
@@ -533,7 +533,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
               val reads  = service.unloadingRemarkReads(userAnswers)
               val result = userAnswers.data.as[UnloadingRemarkType](reads)
 
-              result mustBe UnloadingRemarkType(
+              result mustEqual UnloadingRemarkType(
                 conform = Number0,
                 unloadingCompletion = Number0,
                 unloadingDate = XMLCalendar("2020-01-01"),
@@ -555,7 +555,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
         val reads  = service.unloadingRemarkReads(userAnswers)
         val result = userAnswers.data.as[UnloadingRemarkType](reads)
 
-        result mustBe UnloadingRemarkType(
+        result mustEqual UnloadingRemarkType(
           conform = Number0,
           unloadingCompletion = Number1,
           unloadingDate = XMLCalendar("2020-01-01"),
@@ -572,26 +572,30 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
       (userAnswers.data \ "Consignment").get.as[Option[ConsignmentType06]](reads)
 
     "must create consignment" - {
-      import pages.{GrossWeightPage, NewAuthYesNoPage}
+      import pages.{GrossWeightPage, NewAuthYesNoPage, UniqueConsignmentReferencePage}
 
-      val grossMass = BigDecimal(100)
+      val grossMass          = BigDecimal(100)
+      val referenceNumberUCR = "bar"
 
       "when there are discrepancies" - {
         "when values defined in IE043" in {
           forAll(arbitrary[ConsignmentType05]) {
             consignment =>
               val ie043 = consignment.copy(
-                grossMass = Some(50)
+                grossMass = Some(50),
+                referenceNumberUCR = Some("foo")
               )
 
               val userAnswers = emptyUserAnswers
                 .setValue(NewAuthYesNoPage, false)
                 .setValue(GrossWeightPage, grossMass)
+                .setValue(UniqueConsignmentReferencePage, referenceNumberUCR)
 
               val reads  = service.consignmentReads(Some(ie043))
               val result = getResult(userAnswers, reads)
 
-              result.value.grossMass mustBe Some(grossMass)
+              result.value.grossMass.value mustEqual grossMass
+              result.value.referenceNumberUCR.value mustEqual referenceNumberUCR
           }
         }
 
@@ -599,17 +603,20 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           forAll(arbitrary[ConsignmentType05]) {
             consignment =>
               val ie043 = consignment.copy(
-                grossMass = None
+                grossMass = None,
+                referenceNumberUCR = None
               )
 
               val userAnswers = emptyUserAnswers
                 .setValue(NewAuthYesNoPage, false)
                 .setValue(GrossWeightPage, grossMass)
+                .setValue(UniqueConsignmentReferencePage, referenceNumberUCR)
 
               val reads  = service.consignmentReads(Some(ie043))
               val result = getResult(userAnswers, reads)
 
-              result.value.grossMass mustBe Some(grossMass)
+              result.value.grossMass.value mustEqual grossMass
+              result.value.referenceNumberUCR.value mustEqual referenceNumberUCR
           }
         }
       }
@@ -617,16 +624,20 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
       "when there are no discrepancies" in {
         forAll(arbitrary[ConsignmentType05]) {
           consignment =>
-            val ie043 = consignment.copy(grossMass = Some(grossMass))
+            val ie043 = consignment.copy(
+              grossMass = Some(grossMass),
+              referenceNumberUCR = Some(referenceNumberUCR)
+            )
 
             val userAnswers = emptyUserAnswers
               .setValue(NewAuthYesNoPage, false)
               .setValue(GrossWeightPage, grossMass)
+              .setValue(UniqueConsignmentReferencePage, referenceNumberUCR)
 
             val reads  = service.consignmentReads(Some(ie043))
             val result = getResult(userAnswers, reads)
 
-            result mustBe None
+            result mustEqual None
         }
       }
     }
@@ -638,253 +649,513 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
       import pages.transportEquipment.index.seals.SealIdentificationNumberPage
       import pages.{ContainerIdentificationNumberPage, NewAuthYesNoPage}
 
-      "when there are discrepancies" in {
-        forAll(arbitrary[ConsignmentType05]) {
-          consignment =>
-            val transportEquipment = Seq(
-              TransportEquipmentType03(
-                sequenceNumber = 1,
-                containerIdentificationNumber = Some("originalTransportEquipment1ContainerIdentificationNumber"),
-                numberOfSeals = 2,
-                Seal = Seq(
-                  SealType01(
-                    sequenceNumber = 1,
-                    identifier = "originalTransportEquipment1SealIdentifier1"
-                  ),
-                  SealType01(
-                    sequenceNumber = 2,
-                    identifier = "originalTransportEquipment1SealIdentifier2"
-                  ),
-                  SealType01(
-                    sequenceNumber = 3,
-                    identifier = "originalTransportEquipment1SealIdentifier3"
+      "when there are discrepancies" - {
+        "when phase 5" in {
+          running(phase5App) {
+            app =>
+              val service = app.injector.instanceOf[SubmissionService]
+              forAll(arbitrary[ConsignmentType05]) {
+                consignment =>
+                  val transportEquipment = Seq(
+                    TransportEquipmentType03(
+                      sequenceNumber = 1,
+                      containerIdentificationNumber = Some("originalTransportEquipment1ContainerIdentificationNumber"),
+                      numberOfSeals = 2,
+                      Seal = Seq(
+                        SealType01(
+                          sequenceNumber = 1,
+                          identifier = "originalTransportEquipment1SealIdentifier1"
+                        ),
+                        SealType01(
+                          sequenceNumber = 2,
+                          identifier = "originalTransportEquipment1SealIdentifier2"
+                        ),
+                        SealType01(
+                          sequenceNumber = 3,
+                          identifier = "originalTransportEquipment1SealIdentifier3"
+                        )
+                      ),
+                      GoodsReference = Seq(
+                        GoodsReferenceType01(
+                          sequenceNumber = 1,
+                          declarationGoodsItemNumber = 1
+                        ),
+                        GoodsReferenceType01(
+                          sequenceNumber = 2,
+                          declarationGoodsItemNumber = 2
+                        ),
+                        GoodsReferenceType01(
+                          sequenceNumber = 3,
+                          declarationGoodsItemNumber = 3
+                        )
+                      )
+                    ),
+                    TransportEquipmentType03(
+                      sequenceNumber = 2,
+                      containerIdentificationNumber = Some("originalTransportEquipment2ContainerIdentificationNumber"),
+                      numberOfSeals = 2,
+                      Seal = Seq(
+                        SealType01(
+                          sequenceNumber = 1,
+                          identifier = "originalTransportEquipment2SealIdentifier1"
+                        ),
+                        SealType01(
+                          sequenceNumber = 2,
+                          identifier = "originalTransportEquipment2SealIdentifier2"
+                        ),
+                        SealType01(
+                          sequenceNumber = 3,
+                          identifier = "originalTransportEquipment2SealIdentifier3"
+                        )
+                      ),
+                      GoodsReference = Seq(
+                        GoodsReferenceType01(
+                          sequenceNumber = 1,
+                          declarationGoodsItemNumber = 4
+                        ),
+                        GoodsReferenceType01(
+                          sequenceNumber = 2,
+                          declarationGoodsItemNumber = 5
+                        ),
+                        GoodsReferenceType01(
+                          sequenceNumber = 3,
+                          declarationGoodsItemNumber = 6
+                        )
+                      )
+                    )
                   )
-                ),
-                GoodsReference = Seq(
-                  GoodsReferenceType01(
-                    sequenceNumber = 1,
-                    declarationGoodsItemNumber = 1
-                  ),
-                  GoodsReferenceType01(
-                    sequenceNumber = 2,
-                    declarationGoodsItemNumber = 2
-                  ),
-                  GoodsReferenceType01(
-                    sequenceNumber = 3,
-                    declarationGoodsItemNumber = 3
-                  )
-                )
-              ),
-              TransportEquipmentType03(
-                sequenceNumber = 2,
-                containerIdentificationNumber = Some("originalTransportEquipment2ContainerIdentificationNumber"),
-                numberOfSeals = 2,
-                Seal = Seq(
-                  SealType01(
-                    sequenceNumber = 1,
-                    identifier = "originalTransportEquipment2SealIdentifier1"
-                  ),
-                  SealType01(
-                    sequenceNumber = 2,
-                    identifier = "originalTransportEquipment2SealIdentifier2"
-                  ),
-                  SealType01(
-                    sequenceNumber = 3,
-                    identifier = "originalTransportEquipment2SealIdentifier3"
-                  )
-                ),
-                GoodsReference = Seq(
-                  GoodsReferenceType01(
-                    sequenceNumber = 1,
-                    declarationGoodsItemNumber = 4
-                  ),
-                  GoodsReferenceType01(
-                    sequenceNumber = 2,
-                    declarationGoodsItemNumber = 5
-                  ),
-                  GoodsReferenceType01(
-                    sequenceNumber = 3,
-                    declarationGoodsItemNumber = 6
-                  )
-                )
-              )
-            )
-            val ie043 = consignment.copy(TransportEquipment = transportEquipment)
+                  val ie043 = consignment.copy(TransportEquipment = transportEquipment)
 
-            val userAnswers = emptyUserAnswers
-              .setValue(NewAuthYesNoPage, false)
-              // Transport equipment 1 - Changed
-              .setSequenceNumber(TransportEquipmentSection(Index(0)), 1)
-              .setNotRemoved(TransportEquipmentSection(Index(0)))
-              .setValue(ContainerIdentificationNumberPage(Index(0)), "originalTransportEquipment1ContainerIdentificationNumber")
-              /// Transport equipment 1 - Seal 1 - Unchanged
-              .setSequenceNumber(SealSection(Index(0), Index(0)), 1)
-              .setNotRemoved(SealSection(Index(0), Index(0)))
-              .setValue(SealIdentificationNumberPage(Index(0), Index(0)), "originalTransportEquipment1SealIdentifier1")
-              /// Transport equipment 1 - Seal 2 - Changed
-              .setSequenceNumber(SealSection(Index(0), Index(1)), 2)
-              .setNotRemoved(SealSection(Index(0), Index(1)))
-              .setValue(SealIdentificationNumberPage(Index(0), Index(1)), "newTransportEquipment1SealIdentifier2")
-              /// Transport equipment 1 - Seal 3 - Removed
-              .setSequenceNumber(SealSection(Index(0), Index(2)), 3)
-              .setRemoved(SealSection(Index(0), Index(2)))
-              .setValue(SealIdentificationNumberPage(Index(0), Index(2)), "originalTransportEquipment1SealIdentifier3")
-              /// Transport equipment 1 - Seal 4 - Added
-              .setValue(SealIdentificationNumberPage(Index(0), Index(3)), "newTransportEquipment1SealIdentifier4")
-              /// Transport equipment 1 - Goods reference 1 - Unchanged
-              .setSequenceNumber(ItemSection(Index(0), Index(0)), 1)
-              .setNotRemoved(ItemSection(Index(0), Index(0)))
-              .setValue(ItemPage(Index(0), Index(0)), BigInt(1))
-              /// Transport equipment 1 - Goods reference 2 - Changed
-              .setSequenceNumber(ItemSection(Index(0), Index(1)), 2)
-              .setNotRemoved(ItemSection(Index(0), Index(1)))
-              .setValue(ItemPage(Index(0), Index(1)), BigInt(7))
-              /// Transport equipment 1 - Goods reference 3 - Removed
-              .setSequenceNumber(ItemSection(Index(0), Index(2)), 3)
-              .setRemoved(ItemSection(Index(0), Index(2)))
-              .setValue(ItemPage(Index(0), Index(2)), BigInt(3))
-              /// Transport equipment 1 - Goods reference 4 - Added
-              .setValue(ItemPage(Index(0), Index(3)), BigInt(8))
+                  val userAnswers = emptyUserAnswers
+                    .setValue(NewAuthYesNoPage, false)
+                    // Transport equipment 1 - Changed
+                    .setSequenceNumber(TransportEquipmentSection(Index(0)), 1)
+                    .setNotRemoved(TransportEquipmentSection(Index(0)))
+                    .setValue(ContainerIdentificationNumberPage(Index(0)), "originalTransportEquipment1ContainerIdentificationNumber")
+                    /// Transport equipment 1 - Seal 1 - Unchanged
+                    .setSequenceNumber(SealSection(Index(0), Index(0)), 1)
+                    .setNotRemoved(SealSection(Index(0), Index(0)))
+                    .setValue(SealIdentificationNumberPage(Index(0), Index(0)), "originalTransportEquipment1SealIdentifier1")
+                    /// Transport equipment 1 - Seal 2 - Changed
+                    .setSequenceNumber(SealSection(Index(0), Index(1)), 2)
+                    .setNotRemoved(SealSection(Index(0), Index(1)))
+                    .setValue(SealIdentificationNumberPage(Index(0), Index(1)), "newTransportEquipment1SealIdentifier2")
+                    /// Transport equipment 1 - Seal 3 - Removed
+                    .setSequenceNumber(SealSection(Index(0), Index(2)), 3)
+                    .setRemoved(SealSection(Index(0), Index(2)))
+                    .setValue(SealIdentificationNumberPage(Index(0), Index(2)), "originalTransportEquipment1SealIdentifier3")
+                    /// Transport equipment 1 - Seal 4 - Added
+                    .setValue(SealIdentificationNumberPage(Index(0), Index(3)), "newTransportEquipment1SealIdentifier4")
+                    /// Transport equipment 1 - Goods reference 1 - Unchanged
+                    .setSequenceNumber(ItemSection(Index(0), Index(0)), 1)
+                    .setNotRemoved(ItemSection(Index(0), Index(0)))
+                    .setValue(ItemPage(Index(0), Index(0)), BigInt(1))
+                    /// Transport equipment 1 - Goods reference 2 - Changed
+                    .setSequenceNumber(ItemSection(Index(0), Index(1)), 2)
+                    .setNotRemoved(ItemSection(Index(0), Index(1)))
+                    .setValue(ItemPage(Index(0), Index(1)), BigInt(7))
+                    /// Transport equipment 1 - Goods reference 3 - Removed
+                    .setSequenceNumber(ItemSection(Index(0), Index(2)), 3)
+                    .setRemoved(ItemSection(Index(0), Index(2)))
+                    .setValue(ItemPage(Index(0), Index(2)), BigInt(3))
+                    /// Transport equipment 1 - Goods reference 4 - Added
+                    .setValue(ItemPage(Index(0), Index(3)), BigInt(8))
 
-              // Transport equipment 2 - Changed
-              .setSequenceNumber(TransportEquipmentSection(Index(1)), 2)
-              .setNotRemoved(TransportEquipmentSection(Index(1)))
-              .setValue(ContainerIdentificationNumberPage(Index(1)), "newTransportEquipment2ContainerIdentificationNumber")
-              /// Transport equipment 2 - Seal 1 - Changed
-              .setSequenceNumber(SealSection(Index(1), Index(0)), 1)
-              .setNotRemoved(SealSection(Index(1), Index(0)))
-              .setValue(SealIdentificationNumberPage(Index(1), Index(0)), "newTransportEquipment2SealIdentifier1")
-              /// Transport equipment 2 - Seal 2 - Unchanged
-              .setSequenceNumber(SealSection(Index(1), Index(1)), 2)
-              .setNotRemoved(SealSection(Index(1), Index(1)))
-              .setValue(SealIdentificationNumberPage(Index(1), Index(1)), "originalTransportEquipment2SealIdentifier2")
-              /// Transport equipment 2 - Seal 3 - Removed
-              .setSequenceNumber(SealSection(Index(1), Index(2)), 3)
-              .setRemoved(SealSection(Index(1), Index(2)))
-              .setValue(SealIdentificationNumberPage(Index(1), Index(2)), "originalTransportEquipment2SealIdentifier3")
-              /// Transport equipment 2 - Seal 4 - Added
-              .setValue(SealIdentificationNumberPage(Index(1), Index(3)), "newTransportEquipment2SealIdentifier4")
-              /// Transport equipment 2 - Goods reference 1 - Unchanged
-              .setSequenceNumber(ItemSection(Index(1), Index(0)), 1)
-              .setNotRemoved(ItemSection(Index(1), Index(0)))
-              .setValue(ItemPage(Index(1), Index(0)), BigInt(4))
-              /// Transport equipment 2 - Goods reference 2 - Changed
-              .setSequenceNumber(ItemSection(Index(1), Index(1)), 2)
-              .setNotRemoved(ItemSection(Index(1), Index(1)))
-              .setValue(ItemPage(Index(1), Index(1)), BigInt(9))
-              /// Transport equipment 2 - Goods reference 3 - Removed
-              .setSequenceNumber(ItemSection(Index(1), Index(2)), 3)
-              .setRemoved(ItemSection(Index(1), Index(2)))
-              .setValue(ItemPage(Index(1), Index(2)), BigInt(6))
-              /// Transport equipment 2 - Goods reference 4 - Added
-              .setValue(ItemPage(Index(1), Index(3)), BigInt(10))
+                    // Transport equipment 2 - Changed
+                    .setSequenceNumber(TransportEquipmentSection(Index(1)), 2)
+                    .setNotRemoved(TransportEquipmentSection(Index(1)))
+                    .setValue(ContainerIdentificationNumberPage(Index(1)), "newTransportEquipment2ContainerIdentificationNumber")
+                    /// Transport equipment 2 - Seal 1 - Changed
+                    .setSequenceNumber(SealSection(Index(1), Index(0)), 1)
+                    .setNotRemoved(SealSection(Index(1), Index(0)))
+                    .setValue(SealIdentificationNumberPage(Index(1), Index(0)), "newTransportEquipment2SealIdentifier1")
+                    /// Transport equipment 2 - Seal 2 - Unchanged
+                    .setSequenceNumber(SealSection(Index(1), Index(1)), 2)
+                    .setNotRemoved(SealSection(Index(1), Index(1)))
+                    .setValue(SealIdentificationNumberPage(Index(1), Index(1)), "originalTransportEquipment2SealIdentifier2")
+                    /// Transport equipment 2 - Seal 3 - Removed
+                    .setSequenceNumber(SealSection(Index(1), Index(2)), 3)
+                    .setRemoved(SealSection(Index(1), Index(2)))
+                    .setValue(SealIdentificationNumberPage(Index(1), Index(2)), "originalTransportEquipment2SealIdentifier3")
+                    /// Transport equipment 2 - Seal 4 - Added
+                    .setValue(SealIdentificationNumberPage(Index(1), Index(3)), "newTransportEquipment2SealIdentifier4")
+                    /// Transport equipment 2 - Goods reference 1 - Unchanged
+                    .setSequenceNumber(ItemSection(Index(1), Index(0)), 1)
+                    .setNotRemoved(ItemSection(Index(1), Index(0)))
+                    .setValue(ItemPage(Index(1), Index(0)), BigInt(4))
+                    /// Transport equipment 2 - Goods reference 2 - Changed
+                    .setSequenceNumber(ItemSection(Index(1), Index(1)), 2)
+                    .setNotRemoved(ItemSection(Index(1), Index(1)))
+                    .setValue(ItemPage(Index(1), Index(1)), BigInt(9))
+                    /// Transport equipment 2 - Goods reference 3 - Removed
+                    .setSequenceNumber(ItemSection(Index(1), Index(2)), 3)
+                    .setRemoved(ItemSection(Index(1), Index(2)))
+                    .setValue(ItemPage(Index(1), Index(2)), BigInt(6))
+                    /// Transport equipment 2 - Goods reference 4 - Added
+                    .setValue(ItemPage(Index(1), Index(3)), BigInt(10))
 
-              // Transport equipment 3 - Removed
-              .setSequenceNumber(TransportEquipmentSection(Index(2)), 3)
-              .setRemoved(TransportEquipmentSection(Index(2)))
+                    // Transport equipment 3 - Removed
+                    .setSequenceNumber(TransportEquipmentSection(Index(2)), 3)
+                    .setRemoved(TransportEquipmentSection(Index(2)))
 
-              // Transport equipment 4 - Added
-              .setValue(ContainerIdentificationNumberPage(Index(3)), "newTransportEquipment4ContainerIdentificationNumber")
-              /// Transport equipment 4 - Seal 1 - Added
-              .setValue(SealIdentificationNumberPage(Index(3), Index(0)), "newTransportEquipment4SealIdentifier1")
-              /// Transport equipment 4 - Goods reference 1 - Added
-              .setValue(ItemPage(Index(3), Index(0)), BigInt(9))
+                    // Transport equipment 4 - Added
+                    .setValue(ContainerIdentificationNumberPage(Index(3)), "newTransportEquipment4ContainerIdentificationNumber")
+                    /// Transport equipment 4 - Seal 1 - Added
+                    .setValue(SealIdentificationNumberPage(Index(3), Index(0)), "newTransportEquipment4SealIdentifier1")
+                    /// Transport equipment 4 - Goods reference 1 - Added
+                    .setValue(ItemPage(Index(3), Index(0)), BigInt(9))
 
-            val reads  = service.consignmentReads(Some(ie043))
-            val result = getResult(userAnswers, reads).value.TransportEquipment
+                  val reads  = service.consignmentReads(Some(ie043))
+                  val result = getResult(userAnswers, reads).value.TransportEquipment
 
-            result mustBe Seq(
-              TransportEquipmentType04(
-                sequenceNumber = 1,
-                containerIdentificationNumber = None,
-                numberOfSeals = Some(3),
-                Seal = Seq(
-                  SealType02(
-                    sequenceNumber = 2,
-                    identifier = Some("newTransportEquipment1SealIdentifier2")
-                  ),
-                  SealType02(
-                    sequenceNumber = 3,
-                    identifier = Some("originalTransportEquipment1SealIdentifier3")
-                  ),
-                  SealType02(
-                    sequenceNumber = 4,
-                    identifier = Some("newTransportEquipment1SealIdentifier4")
+                  result mustEqual Seq(
+                    TransportEquipmentType04(
+                      sequenceNumber = 1,
+                      containerIdentificationNumber = None,
+                      numberOfSeals = Some(3),
+                      Seal = Seq(
+                        SealType02(
+                          sequenceNumber = 2,
+                          identifier = Some("newTransportEquipment1SealIdentifier2")
+                        ),
+                        SealType02(
+                          sequenceNumber = 3,
+                          identifier = Some("originalTransportEquipment1SealIdentifier3")
+                        ),
+                        SealType02(
+                          sequenceNumber = 4,
+                          identifier = Some("newTransportEquipment1SealIdentifier4")
+                        )
+                      ),
+                      GoodsReference = Seq(
+                        GoodsReferenceType02(
+                          sequenceNumber = 2,
+                          declarationGoodsItemNumber = Some(7)
+                        ),
+                        GoodsReferenceType02(
+                          sequenceNumber = 3,
+                          declarationGoodsItemNumber = Some(3)
+                        ),
+                        GoodsReferenceType02(
+                          sequenceNumber = 4,
+                          declarationGoodsItemNumber = Some(8)
+                        )
+                      )
+                    ),
+                    TransportEquipmentType04(
+                      sequenceNumber = 2,
+                      containerIdentificationNumber = Some("newTransportEquipment2ContainerIdentificationNumber"),
+                      numberOfSeals = Some(3),
+                      Seal = Seq(
+                        SealType02(
+                          sequenceNumber = 1,
+                          identifier = Some("newTransportEquipment2SealIdentifier1")
+                        ),
+                        SealType02(
+                          sequenceNumber = 3,
+                          identifier = Some("originalTransportEquipment2SealIdentifier3")
+                        ),
+                        SealType02(
+                          sequenceNumber = 4,
+                          identifier = Some("newTransportEquipment2SealIdentifier4")
+                        )
+                      ),
+                      GoodsReference = Seq(
+                        GoodsReferenceType02(
+                          sequenceNumber = 2,
+                          declarationGoodsItemNumber = Some(9)
+                        ),
+                        GoodsReferenceType02(
+                          sequenceNumber = 3,
+                          declarationGoodsItemNumber = Some(6)
+                        ),
+                        GoodsReferenceType02(
+                          sequenceNumber = 4,
+                          declarationGoodsItemNumber = Some(10)
+                        )
+                      )
+                    ),
+                    TransportEquipmentType04(
+                      sequenceNumber = 3,
+                      containerIdentificationNumber = None,
+                      numberOfSeals = None,
+                      Seal = Nil,
+                      GoodsReference = Nil
+                    ),
+                    TransportEquipmentType04(
+                      sequenceNumber = 4,
+                      containerIdentificationNumber = Some("newTransportEquipment4ContainerIdentificationNumber"),
+                      numberOfSeals = Some(1),
+                      Seal = Seq(
+                        SealType02(
+                          sequenceNumber = 1,
+                          identifier = Some("newTransportEquipment4SealIdentifier1")
+                        )
+                      ),
+                      GoodsReference = Seq(
+                        GoodsReferenceType02(
+                          sequenceNumber = 1,
+                          declarationGoodsItemNumber = Some(9)
+                        )
+                      )
+                    )
                   )
-                ),
-                GoodsReference = Seq(
-                  GoodsReferenceType02(
-                    sequenceNumber = 2,
-                    declarationGoodsItemNumber = Some(7)
-                  ),
-                  GoodsReferenceType02(
-                    sequenceNumber = 3,
-                    declarationGoodsItemNumber = Some(3)
-                  ),
-                  GoodsReferenceType02(
-                    sequenceNumber = 4,
-                    declarationGoodsItemNumber = Some(8)
+              }
+          }
+        }
+
+        "when phase 6" in {
+          running(phase6App) {
+            app =>
+              val service = app.injector.instanceOf[SubmissionService]
+              forAll(arbitrary[ConsignmentType05]) {
+                consignment =>
+                  val transportEquipment = Seq(
+                    TransportEquipmentType03(
+                      sequenceNumber = 1,
+                      containerIdentificationNumber = Some("originalTransportEquipment1ContainerIdentificationNumber"),
+                      numberOfSeals = 2,
+                      Seal = Seq(
+                        SealType01(
+                          sequenceNumber = 1,
+                          identifier = "originalTransportEquipment1SealIdentifier1"
+                        ),
+                        SealType01(
+                          sequenceNumber = 2,
+                          identifier = "originalTransportEquipment1SealIdentifier2"
+                        ),
+                        SealType01(
+                          sequenceNumber = 3,
+                          identifier = "originalTransportEquipment1SealIdentifier3"
+                        )
+                      ),
+                      GoodsReference = Seq(
+                        GoodsReferenceType01(
+                          sequenceNumber = 1,
+                          declarationGoodsItemNumber = 1
+                        ),
+                        GoodsReferenceType01(
+                          sequenceNumber = 2,
+                          declarationGoodsItemNumber = 2
+                        ),
+                        GoodsReferenceType01(
+                          sequenceNumber = 3,
+                          declarationGoodsItemNumber = 3
+                        )
+                      )
+                    ),
+                    TransportEquipmentType03(
+                      sequenceNumber = 2,
+                      containerIdentificationNumber = Some("originalTransportEquipment2ContainerIdentificationNumber"),
+                      numberOfSeals = 2,
+                      Seal = Seq(
+                        SealType01(
+                          sequenceNumber = 1,
+                          identifier = "originalTransportEquipment2SealIdentifier1"
+                        ),
+                        SealType01(
+                          sequenceNumber = 2,
+                          identifier = "originalTransportEquipment2SealIdentifier2"
+                        ),
+                        SealType01(
+                          sequenceNumber = 3,
+                          identifier = "originalTransportEquipment2SealIdentifier3"
+                        )
+                      ),
+                      GoodsReference = Seq(
+                        GoodsReferenceType01(
+                          sequenceNumber = 1,
+                          declarationGoodsItemNumber = 4
+                        ),
+                        GoodsReferenceType01(
+                          sequenceNumber = 2,
+                          declarationGoodsItemNumber = 5
+                        ),
+                        GoodsReferenceType01(
+                          sequenceNumber = 3,
+                          declarationGoodsItemNumber = 6
+                        )
+                      )
+                    )
                   )
-                )
-              ),
-              TransportEquipmentType04(
-                sequenceNumber = 2,
-                containerIdentificationNumber = Some("newTransportEquipment2ContainerIdentificationNumber"),
-                numberOfSeals = Some(3),
-                Seal = Seq(
-                  SealType02(
-                    sequenceNumber = 1,
-                    identifier = Some("newTransportEquipment2SealIdentifier1")
-                  ),
-                  SealType02(
-                    sequenceNumber = 3,
-                    identifier = Some("originalTransportEquipment2SealIdentifier3")
-                  ),
-                  SealType02(
-                    sequenceNumber = 4,
-                    identifier = Some("newTransportEquipment2SealIdentifier4")
+                  val ie043 = consignment.copy(TransportEquipment = transportEquipment)
+
+                  val userAnswers = emptyUserAnswers
+                    .setValue(NewAuthYesNoPage, false)
+                    // Transport equipment 1 - Changed
+                    .setSequenceNumber(TransportEquipmentSection(Index(0)), 1)
+                    .setNotRemoved(TransportEquipmentSection(Index(0)))
+                    .setValue(ContainerIdentificationNumberPage(Index(0)), "originalTransportEquipment1ContainerIdentificationNumber")
+                    /// Transport equipment 1 - Seal 1 - Unchanged
+                    .setSequenceNumber(SealSection(Index(0), Index(0)), 1)
+                    .setNotRemoved(SealSection(Index(0), Index(0)))
+                    .setValue(SealIdentificationNumberPage(Index(0), Index(0)), "originalTransportEquipment1SealIdentifier1")
+                    /// Transport equipment 1 - Seal 2 - Changed
+                    .setSequenceNumber(SealSection(Index(0), Index(1)), 2)
+                    .setNotRemoved(SealSection(Index(0), Index(1)))
+                    .setValue(SealIdentificationNumberPage(Index(0), Index(1)), "newTransportEquipment1SealIdentifier2")
+                    /// Transport equipment 1 - Seal 3 - Removed
+                    .setSequenceNumber(SealSection(Index(0), Index(2)), 3)
+                    .setRemoved(SealSection(Index(0), Index(2)))
+                    .setValue(SealIdentificationNumberPage(Index(0), Index(2)), "originalTransportEquipment1SealIdentifier3")
+                    /// Transport equipment 1 - Seal 4 - Added
+                    .setValue(SealIdentificationNumberPage(Index(0), Index(3)), "newTransportEquipment1SealIdentifier4")
+                    /// Transport equipment 1 - Goods reference 1 - Unchanged
+                    .setSequenceNumber(ItemSection(Index(0), Index(0)), 1)
+                    .setNotRemoved(ItemSection(Index(0), Index(0)))
+                    .setValue(ItemPage(Index(0), Index(0)), BigInt(1))
+                    /// Transport equipment 1 - Goods reference 2 - Changed
+                    .setSequenceNumber(ItemSection(Index(0), Index(1)), 2)
+                    .setNotRemoved(ItemSection(Index(0), Index(1)))
+                    .setValue(ItemPage(Index(0), Index(1)), BigInt(7))
+                    /// Transport equipment 1 - Goods reference 3 - Removed
+                    .setSequenceNumber(ItemSection(Index(0), Index(2)), 3)
+                    .setRemoved(ItemSection(Index(0), Index(2)))
+                    .setValue(ItemPage(Index(0), Index(2)), BigInt(3))
+                    /// Transport equipment 1 - Goods reference 4 - Added
+                    .setValue(ItemPage(Index(0), Index(3)), BigInt(8))
+
+                    // Transport equipment 2 - Changed
+                    .setSequenceNumber(TransportEquipmentSection(Index(1)), 2)
+                    .setNotRemoved(TransportEquipmentSection(Index(1)))
+                    .setValue(ContainerIdentificationNumberPage(Index(1)), "newTransportEquipment2ContainerIdentificationNumber")
+                    /// Transport equipment 2 - Seal 1 - Changed
+                    .setSequenceNumber(SealSection(Index(1), Index(0)), 1)
+                    .setNotRemoved(SealSection(Index(1), Index(0)))
+                    .setValue(SealIdentificationNumberPage(Index(1), Index(0)), "newTransportEquipment2SealIdentifier1")
+                    /// Transport equipment 2 - Seal 2 - Unchanged
+                    .setSequenceNumber(SealSection(Index(1), Index(1)), 2)
+                    .setNotRemoved(SealSection(Index(1), Index(1)))
+                    .setValue(SealIdentificationNumberPage(Index(1), Index(1)), "originalTransportEquipment2SealIdentifier2")
+                    /// Transport equipment 2 - Seal 3 - Removed
+                    .setSequenceNumber(SealSection(Index(1), Index(2)), 3)
+                    .setRemoved(SealSection(Index(1), Index(2)))
+                    .setValue(SealIdentificationNumberPage(Index(1), Index(2)), "originalTransportEquipment2SealIdentifier3")
+                    /// Transport equipment 2 - Seal 4 - Added
+                    .setValue(SealIdentificationNumberPage(Index(1), Index(3)), "newTransportEquipment2SealIdentifier4")
+                    /// Transport equipment 2 - Goods reference 1 - Unchanged
+                    .setSequenceNumber(ItemSection(Index(1), Index(0)), 1)
+                    .setNotRemoved(ItemSection(Index(1), Index(0)))
+                    .setValue(ItemPage(Index(1), Index(0)), BigInt(4))
+                    /// Transport equipment 2 - Goods reference 2 - Changed
+                    .setSequenceNumber(ItemSection(Index(1), Index(1)), 2)
+                    .setNotRemoved(ItemSection(Index(1), Index(1)))
+                    .setValue(ItemPage(Index(1), Index(1)), BigInt(9))
+                    /// Transport equipment 2 - Goods reference 3 - Removed
+                    .setSequenceNumber(ItemSection(Index(1), Index(2)), 3)
+                    .setRemoved(ItemSection(Index(1), Index(2)))
+                    .setValue(ItemPage(Index(1), Index(2)), BigInt(6))
+                    /// Transport equipment 2 - Goods reference 4 - Added
+                    .setValue(ItemPage(Index(1), Index(3)), BigInt(10))
+
+                    // Transport equipment 3 - Removed
+                    .setSequenceNumber(TransportEquipmentSection(Index(2)), 3)
+                    .setRemoved(TransportEquipmentSection(Index(2)))
+
+                    // Transport equipment 4 - Added
+                    .setValue(ContainerIdentificationNumberPage(Index(3)), "newTransportEquipment4ContainerIdentificationNumber")
+                    /// Transport equipment 4 - Seal 1 - Added
+                    .setValue(SealIdentificationNumberPage(Index(3), Index(0)), "newTransportEquipment4SealIdentifier1")
+                    /// Transport equipment 4 - Goods reference 1 - Added
+                    .setValue(ItemPage(Index(3), Index(0)), BigInt(9))
+
+                  val reads  = service.consignmentReads(Some(ie043))
+                  val result = getResult(userAnswers, reads).value.TransportEquipment
+
+                  result mustEqual Seq(
+                    TransportEquipmentType04(
+                      sequenceNumber = 1,
+                      containerIdentificationNumber = None,
+                      numberOfSeals = Some(3),
+                      Seal = Seq(
+                        SealType02(
+                          sequenceNumber = 2,
+                          identifier = Some("newTransportEquipment1SealIdentifier2")
+                        ),
+                        SealType02(
+                          sequenceNumber = 3,
+                          identifier = None
+                        ),
+                        SealType02(
+                          sequenceNumber = 4,
+                          identifier = Some("newTransportEquipment1SealIdentifier4")
+                        )
+                      ),
+                      GoodsReference = Seq(
+                        GoodsReferenceType02(
+                          sequenceNumber = 2,
+                          declarationGoodsItemNumber = Some(7)
+                        ),
+                        GoodsReferenceType02(
+                          sequenceNumber = 3,
+                          declarationGoodsItemNumber = None
+                        ),
+                        GoodsReferenceType02(
+                          sequenceNumber = 4,
+                          declarationGoodsItemNumber = Some(8)
+                        )
+                      )
+                    ),
+                    TransportEquipmentType04(
+                      sequenceNumber = 2,
+                      containerIdentificationNumber = Some("newTransportEquipment2ContainerIdentificationNumber"),
+                      numberOfSeals = Some(3),
+                      Seal = Seq(
+                        SealType02(
+                          sequenceNumber = 1,
+                          identifier = Some("newTransportEquipment2SealIdentifier1")
+                        ),
+                        SealType02(
+                          sequenceNumber = 3,
+                          identifier = None
+                        ),
+                        SealType02(
+                          sequenceNumber = 4,
+                          identifier = Some("newTransportEquipment2SealIdentifier4")
+                        )
+                      ),
+                      GoodsReference = Seq(
+                        GoodsReferenceType02(
+                          sequenceNumber = 2,
+                          declarationGoodsItemNumber = Some(9)
+                        ),
+                        GoodsReferenceType02(
+                          sequenceNumber = 3,
+                          declarationGoodsItemNumber = None
+                        ),
+                        GoodsReferenceType02(
+                          sequenceNumber = 4,
+                          declarationGoodsItemNumber = Some(10)
+                        )
+                      )
+                    ),
+                    TransportEquipmentType04(
+                      sequenceNumber = 3,
+                      containerIdentificationNumber = None,
+                      numberOfSeals = None,
+                      Seal = Nil,
+                      GoodsReference = Nil
+                    ),
+                    TransportEquipmentType04(
+                      sequenceNumber = 4,
+                      containerIdentificationNumber = Some("newTransportEquipment4ContainerIdentificationNumber"),
+                      numberOfSeals = Some(1),
+                      Seal = Seq(
+                        SealType02(
+                          sequenceNumber = 1,
+                          identifier = Some("newTransportEquipment4SealIdentifier1")
+                        )
+                      ),
+                      GoodsReference = Seq(
+                        GoodsReferenceType02(
+                          sequenceNumber = 1,
+                          declarationGoodsItemNumber = Some(9)
+                        )
+                      )
+                    )
                   )
-                ),
-                GoodsReference = Seq(
-                  GoodsReferenceType02(
-                    sequenceNumber = 2,
-                    declarationGoodsItemNumber = Some(9)
-                  ),
-                  GoodsReferenceType02(
-                    sequenceNumber = 3,
-                    declarationGoodsItemNumber = Some(6)
-                  ),
-                  GoodsReferenceType02(
-                    sequenceNumber = 4,
-                    declarationGoodsItemNumber = Some(10)
-                  )
-                )
-              ),
-              TransportEquipmentType04(
-                sequenceNumber = 3,
-                containerIdentificationNumber = None,
-                numberOfSeals = None,
-                Seal = Nil,
-                GoodsReference = Nil
-              ),
-              TransportEquipmentType04(
-                sequenceNumber = 4,
-                containerIdentificationNumber = Some("newTransportEquipment4ContainerIdentificationNumber"),
-                numberOfSeals = Some(1),
-                Seal = Seq(
-                  SealType02(
-                    sequenceNumber = 1,
-                    identifier = Some("newTransportEquipment4SealIdentifier1")
-                  )
-                ),
-                GoodsReference = Seq(
-                  GoodsReferenceType02(
-                    sequenceNumber = 1,
-                    declarationGoodsItemNumber = Some(9)
-                  )
-                )
-              )
-            )
+              }
+          }
         }
       }
 
@@ -992,7 +1263,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentReads(Some(ie043))
             val result = getResult(userAnswers, reads)
 
-            result mustBe None
+            result mustEqual None
         }
       }
     }
@@ -1072,7 +1343,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentReads(Some(ie043))
             val result = getResult(userAnswers, reads).value.DepartureTransportMeans
 
-            result mustBe Seq(
+            result mustEqual Seq(
               DepartureTransportMeansType02(
                 sequenceNumber = 1,
                 typeOfIdentification = Some("newTypeOfIdentification1"),
@@ -1140,7 +1411,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentReads(Some(ie043))
             val result = getResult(userAnswers, reads)
 
-            result mustBe None
+            result mustEqual None
         }
       }
     }
@@ -1213,7 +1484,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentReads(Some(ie043))
             val result = getResult(userAnswers, reads).value.SupportingDocument
 
-            result mustBe Seq(
+            result mustEqual Seq(
               SupportingDocumentType04(
                 sequenceNumber = 1,
                 typeValue = Some("newTypeValue1"),
@@ -1279,7 +1550,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentReads(Some(ie043))
             val result = getResult(userAnswers, reads)
 
-            result mustBe None
+            result mustEqual None
         }
       }
     }
@@ -1344,7 +1615,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentReads(Some(ie043))
             val result = getResult(userAnswers, reads).value.TransportDocument
 
-            result mustBe Seq(
+            result mustEqual Seq(
               TransportDocumentType04(
                 sequenceNumber = 1,
                 typeValue = Some("newTypeValue1"),
@@ -1402,7 +1673,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentReads(Some(ie043))
             val result = getResult(userAnswers, reads)
 
-            result mustBe None
+            result mustEqual None
         }
       }
     }
@@ -1466,7 +1737,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentReads(Some(ie043))
             val result = getResult(userAnswers, reads).value.AdditionalReference
 
-            result mustBe Seq(
+            result mustEqual Seq(
               AdditionalReferenceType03(
                 sequenceNumber = 1,
                 typeValue = Some("newTypeValue1"),
@@ -1524,7 +1795,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentReads(Some(ie043))
             val result = getResult(userAnswers, reads)
 
-            result mustBe None
+            result mustEqual None
         }
       }
     }
@@ -1541,7 +1812,8 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
 
     "must create house consignment" - {
 
-      val grossMass = BigDecimal(100)
+      val grossMass          = BigDecimal(100)
+      val referenceNumberUCR = "bar"
 
       "when there are discrepancies" - {
         "when values defined in IE043" in {
@@ -1549,18 +1821,21 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             houseConsignment =>
               val ie043 = houseConsignment.copy(
                 sequenceNumber = sequenceNumber,
-                grossMass = 50
+                grossMass = 50,
+                referenceNumberUCR = Some("foo")
               )
 
               val userAnswers = emptyUserAnswers
                 .setValue(NewAuthYesNoPage, false)
                 .setSequenceNumber(HouseConsignmentSection(Index(0)), 1)
                 .setValue(GrossWeightPage(Index(0)), grossMass)
+                .setValue(UniqueConsignmentReferencePage(Index(0)), referenceNumberUCR)
 
               val reads  = service.houseConsignmentReads(Seq(ie043))(Index(0), sequenceNumber)
               val result = getResult(userAnswers, reads)
 
-              result.value.grossMass mustBe Some(grossMass)
+              result.value.grossMass.value mustEqual grossMass
+              result.value.referenceNumberUCR.value mustEqual referenceNumberUCR
           }
         }
       }
@@ -1570,18 +1845,20 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
           houseConsignment =>
             val ie043 = houseConsignment.copy(
               sequenceNumber = sequenceNumber,
-              grossMass = grossMass
+              grossMass = grossMass,
+              referenceNumberUCR = Some(referenceNumberUCR)
             )
 
             val userAnswers = emptyUserAnswers
               .setValue(NewAuthYesNoPage, false)
               .setSequenceNumber(HouseConsignmentSection(Index(0)), 1)
               .setValue(GrossWeightPage(Index(0)), grossMass)
+              .setValue(UniqueConsignmentReferencePage(Index(0)), referenceNumberUCR)
 
             val reads  = service.houseConsignmentReads(Seq(ie043))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads)
 
-            result mustBe None
+            result mustEqual None
         }
       }
     }
@@ -1667,7 +1944,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.houseConsignmentReads(Seq(ie043))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads).value.DepartureTransportMeans
 
-            result mustBe Seq(
+            result mustEqual Seq(
               DepartureTransportMeansType02(
                 sequenceNumber = 1,
                 typeOfIdentification = Some("newTypeOfIdentification1"),
@@ -1742,7 +2019,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.houseConsignmentReads(Seq(ie043))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads)
 
-            result mustBe None
+            result mustEqual None
         }
       }
     }
@@ -1819,7 +2096,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.houseConsignmentReads(Seq(ie043))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads).value.SupportingDocument
 
-            result mustBe Seq(
+            result mustEqual Seq(
               SupportingDocumentType04(
                 sequenceNumber = 1,
                 typeValue = Some("newTypeValue1"),
@@ -1890,7 +2167,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.houseConsignmentReads(Seq(ie043))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads)
 
-            result mustBe None
+            result mustEqual None
         }
       }
     }
@@ -1959,7 +2236,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.houseConsignmentReads(Seq(ie043))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads).value.TransportDocument
 
-            result mustBe Seq(
+            result mustEqual Seq(
               TransportDocumentType04(
                 sequenceNumber = 1,
                 typeValue = Some("newTypeValue1"),
@@ -2022,7 +2299,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.houseConsignmentReads(Seq(ie043))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads)
 
-            result mustBe None
+            result mustEqual None
         }
       }
     }
@@ -2094,7 +2371,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.houseConsignmentReads(Seq(ie043))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads).value.AdditionalReference
 
-            result mustBe Seq(
+            result mustEqual Seq(
               AdditionalReferenceType03(
                 sequenceNumber = 1,
                 typeValue = Some("newTypeValue1"),
@@ -2161,7 +2438,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.houseConsignmentReads(Seq(ie043))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads)
 
-            result mustBe None
+            result mustEqual None
         }
       }
     }
@@ -2228,7 +2505,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.houseConsignmentReads(Seq(ie043))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads).value.ConsignmentItem
 
-            result mustBe Seq(
+            result mustEqual Seq(
               ConsignmentItemType05(
                 goodsItemNumber = 1,
                 declarationGoodsItemNumber = 1,
@@ -2297,7 +2574,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.houseConsignmentReads(Seq(ie043))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads)
 
-            result mustBe None
+            result mustEqual None
         }
       }
     }
@@ -2311,6 +2588,59 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
 
     def getResult(userAnswers: UserAnswers, reads: Reads[Option[ConsignmentItemType05]]): Option[ConsignmentItemType05] =
       (userAnswers.data \ "Consignment" \ "HouseConsignment" \ 0 \ "ConsignmentItem" \ 0).get.as[Option[ConsignmentItemType05]](reads)
+
+    "must create consignment item" - {
+
+      val referenceNumberUCR = "bar"
+
+      "when there are discrepancies" - {
+        "when values defined in IE043" in {
+          forAll(arbitrary[ConsignmentItemType04]) {
+            consignmentItem =>
+              val ie043 = consignmentItem.copy(
+                goodsItemNumber = sequenceNumber,
+                referenceNumberUCR = Some("foo")
+              )
+
+              val userAnswers = emptyUserAnswers
+                .setValue(NewAuthYesNoPage, false)
+                .setNotRemoved(ItemSection(Index(0), Index(0)))
+                .setValue(DeclarationGoodsItemNumberPage(Index(0), Index(0)), BigInt(1))
+                .setValue(UniqueConsignmentReferencePage(Index(0), Index(0)), referenceNumberUCR)
+
+              val reads  = service.consignmentItemReads(Seq(ie043))(Index(0))(Index(0), sequenceNumber)
+              val result = getResult(userAnswers, reads).value
+
+              result mustEqual ConsignmentItemType05(
+                goodsItemNumber = sequenceNumber,
+                declarationGoodsItemNumber = 1,
+                referenceNumberUCR = Some(referenceNumberUCR)
+              )
+          }
+        }
+      }
+
+      "when there are no discrepancies" in {
+        forAll(arbitrary[ConsignmentItemType04]) {
+          consignmentItem =>
+            val ie043 = consignmentItem.copy(
+              goodsItemNumber = sequenceNumber,
+              referenceNumberUCR = Some(referenceNumberUCR)
+            )
+
+            val userAnswers = emptyUserAnswers
+              .setValue(NewAuthYesNoPage, false)
+              .setNotRemoved(ItemSection(Index(0), Index(0)))
+              .setValue(DeclarationGoodsItemNumberPage(Index(0), Index(0)), BigInt(1))
+              .setValue(UniqueConsignmentReferencePage(Index(0), Index(0)), referenceNumberUCR)
+
+            val reads  = service.consignmentItemReads(Seq(ie043))(Index(0))(Index(0), sequenceNumber)
+            val result = getResult(userAnswers, reads)
+
+            result mustEqual None
+        }
+      }
+    }
 
     "must create commodity" - {
 
@@ -2353,7 +2683,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentItemReads(Seq(ie043))(Index(0))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads).value.Commodity.value
 
-            result mustBe CommodityType02(
+            result mustEqual CommodityType02(
               descriptionOfGoods = Some("newDescriptionOfGoods"),
               cusCode = Some("newCusCode"),
               CommodityCode = Some(
@@ -2411,7 +2741,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentItemReads(Seq(ie043))(Index(0))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads)
 
-            result mustBe None
+            result mustEqual None
         }
       }
     }
@@ -2487,7 +2817,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentItemReads(Seq(ie043))(Index(0))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads).value.Packaging
 
-            result mustBe Seq(
+            result mustEqual Seq(
               PackagingType02(
                 sequenceNumber = 1,
                 typeOfPackages = Some("newTypeOfPackages1"),
@@ -2558,7 +2888,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentItemReads(Seq(ie043))(Index(0))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads)
 
-            result mustBe None
+            result mustEqual None
         }
       }
     }
@@ -2635,7 +2965,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentItemReads(Seq(ie043))(Index(0))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads).value.SupportingDocument
 
-            result mustBe Seq(
+            result mustEqual Seq(
               SupportingDocumentType04(
                 sequenceNumber = 1,
                 typeValue = Some("newTypeValue1"),
@@ -2706,7 +3036,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentItemReads(Seq(ie043))(Index(0))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads)
 
-            result mustBe None
+            result mustEqual None
         }
       }
     }
@@ -2775,7 +3105,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentItemReads(Seq(ie043))(Index(0))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads).value.TransportDocument
 
-            result mustBe Seq(
+            result mustEqual Seq(
               TransportDocumentType04(
                 sequenceNumber = 1,
                 typeValue = Some("newTypeValue1"),
@@ -2838,7 +3168,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentItemReads(Seq(ie043))(Index(0))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads)
 
-            result mustBe None
+            result mustEqual None
         }
       }
     }
@@ -2910,7 +3240,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentItemReads(Seq(ie043))(Index(0))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads).value.AdditionalReference
 
-            result mustBe Seq(
+            result mustEqual Seq(
               AdditionalReferenceType03(
                 sequenceNumber = 1,
                 typeValue = Some("newTypeValue1"),
@@ -2977,7 +3307,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentItemReads(Seq(ie043))(Index(0))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads)
 
-            result mustBe None
+            result mustEqual None
         }
       }
     }

--- a/test/services/submission/SubmissionServiceSpec.scala
+++ b/test/services/submission/SubmissionServiceSpec.scala
@@ -637,7 +637,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentReads(Some(ie043))
             val result = getResult(userAnswers, reads)
 
-            result mustEqual None
+            result must not be defined
         }
       }
     }
@@ -1263,7 +1263,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentReads(Some(ie043))
             val result = getResult(userAnswers, reads)
 
-            result mustEqual None
+            result must not be defined
         }
       }
     }
@@ -1411,7 +1411,105 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentReads(Some(ie043))
             val result = getResult(userAnswers, reads)
 
-            result mustEqual None
+            result must not be defined
+        }
+      }
+    }
+
+    "must create countries of routing" - {
+      import pages.NewAuthYesNoPage
+      import pages.countriesOfRouting.*
+      import pages.sections.CountryOfRoutingSection
+
+      "when there are discrepancies" in {
+        forAll(arbitrary[ConsignmentType05]) {
+          consignment =>
+            val countriesOfRouting = Seq(
+              CountryOfRoutingOfConsignmentType02(
+                sequenceNumber = 1,
+                country = "originalCountry1"
+              ),
+              CountryOfRoutingOfConsignmentType02(
+                sequenceNumber = 2,
+                country = "originalCountry2"
+              ),
+              CountryOfRoutingOfConsignmentType02(
+                sequenceNumber = 3,
+                country = "originalCountry3"
+              ),
+              CountryOfRoutingOfConsignmentType02(
+                sequenceNumber = 4,
+                country = "originalCountry4"
+              )
+            )
+            val ie043 = consignment.copy(CountryOfRoutingOfConsignment = countriesOfRouting)
+
+            val userAnswers = emptyUserAnswers
+              .setValue(NewAuthYesNoPage, false)
+              // Country of routing 1 - Changed country value
+              .setSequenceNumber(CountryOfRoutingSection(Index(0)), 1)
+              .setNotRemoved(CountryOfRoutingSection(Index(0)))
+              .setValue(CountryOfRoutingPage(Index(0)), Country("newCountry1", "newCountry1Description"))
+              // Country of routing 2 - Removed
+              .setSequenceNumber(CountryOfRoutingSection(Index(1)), 2)
+              .setRemoved(CountryOfRoutingSection(Index(1)))
+              // Country of routing 3 - Unchanged
+              .setSequenceNumber(CountryOfRoutingSection(Index(2)), 3)
+              .setNotRemoved(CountryOfRoutingSection(Index(2)))
+              .setValue(CountryOfRoutingPage(Index(2)), Country("originalCountry3", "originalCountry3Description"))
+              // Country of routing 4 - Added
+              .setValue(CountryOfRoutingPage(Index(3)), Country("newCountry4", "newCountry4Description"))
+
+            val reads  = service.consignmentReads(Some(ie043))
+            val result = getResult(userAnswers, reads).value.CountryOfRoutingOfConsignment
+
+            result mustEqual Seq(
+              CountryOfRoutingOfConsignmentType03(
+                sequenceNumber = 1,
+                country = Some("newCountry1")
+              ),
+              CountryOfRoutingOfConsignmentType03(
+                sequenceNumber = 2,
+                country = None
+              ),
+              CountryOfRoutingOfConsignmentType03(
+                sequenceNumber = 4,
+                country = Some("newCountry4")
+              )
+            )
+        }
+      }
+
+      "when there are no discrepancies" in {
+        forAll(arbitrary[ConsignmentType05]) {
+          consignment =>
+            val countriesOfRouting = Seq(
+              CountryOfRoutingOfConsignmentType02(
+                sequenceNumber = 1,
+                country = "originalCountry1"
+              ),
+              CountryOfRoutingOfConsignmentType02(
+                sequenceNumber = 2,
+                country = "originalCountry2"
+              )
+            )
+            val ie043 = consignment.copy(CountryOfRoutingOfConsignment = countriesOfRouting)
+
+            val userAnswers = emptyUserAnswers
+              .setValue(NewAuthYesNoPage, false)
+              // Country of routing 1 - Unchanged
+              .setSequenceNumber(CountryOfRoutingSection(Index(0)), 1)
+              .setNotRemoved(CountryOfRoutingSection(Index(0)))
+              .setValue(CountryOfRoutingPage(Index(0)), Country("originalCountry1", "originalCountry1Description"))
+              // Country of routing 2 - Unchanged
+              .setSequenceNumber(CountryOfRoutingSection(Index(1)), 2)
+              .setNotRemoved(CountryOfRoutingSection(Index(1)))
+              .setValue(CountryOfRoutingPage(Index(1)), Country("originalCountry2", "originalCountry2Description"))
+
+            val reads  = service.consignmentReads(Some(ie043))
+            val result = getResult(userAnswers, reads)
+
+            result must not be defined
         }
       }
     }
@@ -1550,7 +1648,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentReads(Some(ie043))
             val result = getResult(userAnswers, reads)
 
-            result mustEqual None
+            result must not be defined
         }
       }
     }
@@ -1673,7 +1771,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentReads(Some(ie043))
             val result = getResult(userAnswers, reads)
 
-            result mustEqual None
+            result must not be defined
         }
       }
     }
@@ -1795,7 +1893,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentReads(Some(ie043))
             val result = getResult(userAnswers, reads)
 
-            result mustEqual None
+            result must not be defined
         }
       }
     }
@@ -1858,7 +1956,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.houseConsignmentReads(Seq(ie043))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads)
 
-            result mustEqual None
+            result must not be defined
         }
       }
     }
@@ -2019,7 +2117,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.houseConsignmentReads(Seq(ie043))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads)
 
-            result mustEqual None
+            result must not be defined
         }
       }
     }
@@ -2167,7 +2265,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.houseConsignmentReads(Seq(ie043))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads)
 
-            result mustEqual None
+            result must not be defined
         }
       }
     }
@@ -2299,7 +2397,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.houseConsignmentReads(Seq(ie043))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads)
 
-            result mustEqual None
+            result must not be defined
         }
       }
     }
@@ -2438,7 +2536,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.houseConsignmentReads(Seq(ie043))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads)
 
-            result mustEqual None
+            result must not be defined
         }
       }
     }
@@ -2574,7 +2672,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.houseConsignmentReads(Seq(ie043))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads)
 
-            result mustEqual None
+            result must not be defined
         }
       }
     }
@@ -2637,7 +2735,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentItemReads(Seq(ie043))(Index(0))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads)
 
-            result mustEqual None
+            result must not be defined
         }
       }
     }
@@ -2741,7 +2839,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentItemReads(Seq(ie043))(Index(0))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads)
 
-            result mustEqual None
+            result must not be defined
         }
       }
     }
@@ -2888,7 +2986,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentItemReads(Seq(ie043))(Index(0))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads)
 
-            result mustEqual None
+            result must not be defined
         }
       }
     }
@@ -3036,7 +3134,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentItemReads(Seq(ie043))(Index(0))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads)
 
-            result mustEqual None
+            result must not be defined
         }
       }
     }
@@ -3168,7 +3266,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentItemReads(Seq(ie043))(Index(0))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads)
 
-            result mustEqual None
+            result must not be defined
         }
       }
     }
@@ -3307,7 +3405,7 @@ class SubmissionServiceSpec extends SpecBase with AppWithDefaultMockFixtures wit
             val reads  = service.consignmentItemReads(Seq(ie043))(Index(0))(Index(0), sequenceNumber)
             val result = getResult(userAnswers, reads)
 
-            result mustEqual None
+            result must not be defined
         }
       }
     }


### PR DESCRIPTION
- Added UCR at all 3 levels to submission logic
- Added countries of routing to submission logic
- Seals and goods references in submission logic are driven by feature toggles (since identifier field was mandatory in p5 and optional in p6)