### PR TITLE
Upgrade libraries: sbt-plugin → 3.0.10, bootstrap-frontend-play-30 → 10.6.0

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,7 +4,7 @@ import sbt.*
 object AppDependencies {
 
   private val mongoVersion = "2.12.0"
-  private val bootstrapVersion = "10.5.0"
+  private val bootstrapVersion = "10.6.0"
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.6.0")
 
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.9")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.10")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0" exclude("org.scala-lang.modules", "scala-xml_2.12"))
 


### PR DESCRIPTION
## Library Upgrades

| Group | Artifact | New Version |
|-------|----------|-------------|
| `org.playframework` | `sbt-plugin` | `3.0.10` |
| `uk.gov.hmrc` | `bootstrap-frontend-play-30` | `10.6.0` |

_This PR was created automatically by the Library Upgrade Tool._